### PR TITLE
Raise error if UDUNITS library not installed

### DIFF
--- a/cfunits/units.py
+++ b/cfunits/units.py
@@ -39,6 +39,10 @@ _ctypes_POINTER = {4: _POINTER(_c_float),
 #    # Linux
 #    _udunits = ctypes.CDLL('libudunits2.so.0')
 _libpath = ctypes.util.find_library('udunits2')
+
+if _libpath is None:
+    raise FileNotFoundError("Error finding the UNIDATA UDUNITS library, please make sure it is installed.")
+
 _udunits = ctypes.CDLL(_libpath)
 
 # Suppress "overrides prefixed-unit" messages. This also suppresses


### PR DESCRIPTION
When using the cf-checker tool that requires cfunits to be installed I was getting an error due to UDUNITS not being installed. I thought this small check could be a good warning to those who haven’t installed the correct dependencies. Apologies for posting on the old repo last time.