### PR TITLE
Test Actions update (generate & upload coverage reports)

### DIFF
--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -89,6 +89,24 @@ jobs:
         cd cfunits/test
         ./run_tests_and_coverage --nohtml
 
+    # For one job only, generate a coverage report:
+    - name: Upload coverage report to Codecov
+      # Get coverage from only one job (choose with Ubuntu Python 3.7 as
+      # representative). Note that we could use a separate workflow
+      # to setup Codecov reports, but given the amount of steps required to
+      # install including dependencies via conda, that a separate workflow
+      # would have to run anyway, it is simplest to add it in this flow.
+      # Also, it means code coverage is only generated if the test suite is
+      # passing at least for that job, avoiding useless coverage reports.
+      uses: codecov/codecov-action@v1.0.13
+      if: |
+        matrix.os == 'ubuntu-latest' && matrix.python-version == 3.7
+      with:
+        file: ./cfunits/test/cfunits_coverage_reports/coverage.xml
+        fail_ci_if_error: true
+        flags: unittests
+        name: codecov-umbrella
+
     # End with a message indicating the suite has completed its run
     - name: Notify about a completed run
       run: |

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -71,16 +71,23 @@ jobs:
         # Important! Must install our development version of cfunits to test:
         pip install -e .
 
+    # Install the coverage library
+    # We do so with conda which was setup in a previous step.
+    - name: Install coverage
+      shell: bash -l {0}
+      run: |
+        conda install coverage
+
     # Provide another notification message
     - name: Notify about starting testing
       run: echo Setup complete. Now starting to run the cfunits test suite...
 
-    # Finally run the test suite!
-    - name: Run test suite
+    # Finally run the test suite and generate a coverage report!
+    - name: Run test suite and generate a coverage report
       shell: bash -l {0}
       run: |
         cd cfunits/test
-        python run_tests.py
+        ./run_tests_and_coverage --nohtml
 
     # End with a message indicating the suite has completed its run
     - name: Notify about a completed run

--- a/cfunits/test/run_tests_and_coverage
+++ b/cfunits/test/run_tests_and_coverage
@@ -1,27 +1,48 @@
 #!/bin/bash
 
-# --------------------------------------------------------------------
-# Run the full test suite and produce a coverage report.
+# --------------------------------------------------------------------------
+# Run the full test suite and produce a coverage report:
 #
 # $ run_test_and_coverage
 #
 # Or to omit the generation of an html report:
 #
 # $ run_test_and_coverage --nohtml
-# --------------------------------------------------------------------
-set -x
+#
+# An XML report is required by Codecov (a code coverage service providing
+# detailed reports with visualisations in-browser) so is created unless set:
+#
+# $ run_test_and_coverage --noxml
+#
+# where running with both the --nohtml and --noxml arguments will omit both
+# reports, just printing a concise result table to STDOUT.
+# --------------------------------------------------------------------------
+
+#set -x
+
 
 library=cfunits
 
-if [[ $1 == "--nohtml" ]] ; then 
-    generate_html="false"
-else
-    generate_html="true"
-fi
+# Parse arguments. Note that XML output is required for codecov:
+generate_xml="true"
+generate_html="true"
+for arg in "$@"
+do
+    if [[ $arg == "--noxml" ]]
+    then
+        generate_xml="false"
+    fi
+    if [[ $arg == "--nohtml" ]]
+    then
+        generate_html="false"
+    fi
+done
 
 if ! command -v coverage &> /dev/null
 then
-    echo "Requires the coverage module: install it e.g. via 'pip install coverage'"
+    echo \
+"Requires the coverage module: install it e.g. via \
+'pip install coverage'"
     exit 3
 fi
 
@@ -32,13 +53,21 @@ rc=$?
 
 coverage report
 
+cov_dir=${library}_coverage_reports
+mkdir -p $cov_dir
+echo "coverage docs: https://coverage.readthedocs.io"
 if [[ $generate_html == "true" ]] ; then
-    dir=${library}_coverage_report
-    mkdir -p $dir
-    coverage html --title "$library test suite coverage report" -d $dir
-    
-    echo "coverage docs: https://coverage.readthedocs.io"
-    echo "coverage report URL: file://$PWD/$dir/index.html"
+    html_dir=$cov_dir/html
+    mkdir -p $html_dir
+    coverage html --title "$library test suite coverage report" -d $html_dir
+
+    echo "coverage HTML report URL: file://$PWD/$html_dir/index.html"
+fi
+if [[ $generate_xml == "true" ]] ; then
+    coverage xml
+    mv "coverage.xml" $cov_dir/"coverage.xml"
+
+    echo "coverage XML report URL: file://$PWD/$cov_dir/coverage.xml"
 fi
 
 # Return exit status from unit tests

--- a/cfunits/units.py
+++ b/cfunits/units.py
@@ -587,7 +587,7 @@ class Units():
     'gregorian'
     >>> v.equals(u)
     True
-    
+
 
     **Arithmetic with units**
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,35 @@
+# This config overrides the default Codecov config, as outlined at:
+# https://docs.codecov.io/docs/codecov-yaml
+
+coverage:
+  round: up
+  range: "70...100"
+  precision: 2
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: "0%"
+        base: auto
+        branches: 
+          - master
+        if_no_uploads: success
+        if_not_found: success  
+        if_ci_failed: error
+        only_pulls: true
+    patch:
+      default:
+        target: "90%"
+        threshold: "10%"
+        base: auto
+        branches:
+          - master
+        if_no_uploads: success
+        if_not_found: success
+        if_ci_failed: error
+        only_pulls: false
+
+# Note: there is a Codecov 'ignore' key to ignore certain paths, but this is
+# not needed (I think) since we ignore the test directory path etc. in
+# generating our coverage XML, so it should already not be processed.

--- a/codecov.yml
+++ b/codecov.yml
@@ -12,10 +12,8 @@ coverage:
         target: auto
         threshold: "0%"
         base: auto
-        branches: 
-          - master
         if_no_uploads: success
-        if_not_found: success  
+        if_not_found: success
         if_ci_failed: error
         only_pulls: true
     patch:
@@ -23,8 +21,6 @@ coverage:
         target: "90%"
         threshold: "10%"
         base: auto
-        branches:
-          - master
         if_no_uploads: success
         if_not_found: success
         if_ci_failed: error


### PR DESCRIPTION
Test and, if/when working, merge, an update to the GH Actions run_test_suite workflow to upload a(XML format) coverage report for one representative job to the Codecov coverage service. See individual commit messages for the sub-steps required to achieve this.

(Direct equivalent to NCAS-CMS/cf-python#121 for cf-python, so see also the description on that PR for the desired outcome.)