### PR TITLE
Setup doctest and fix broken code examples raised

### DIFF
--- a/cfunits/test/run_tests.py
+++ b/cfunits/test/run_tests.py
@@ -1,6 +1,8 @@
 from __future__ import print_function
 
 import unittest
+import doctest
+import pkgutil
 import os
 from random import choice
 import sys
@@ -35,6 +37,12 @@ testsuite.addTests(
         os.path.dirname(os.path.realpath(__file__)), pattern="test_*.py"
     )
 )
+
+# Add a test suite for doctests
+testsuite_doctests = unittest.TestSuite()
+for importer, name, ispkg in (
+        pkgutil.walk_packages(cfunits.__path__, cfunits.__name__ + '.')):
+    testsuite.addTests(doctest.DocTestSuite(name))
 
 
 # Run the test suite.

--- a/cfunits/test/run_tests.py
+++ b/cfunits/test/run_tests.py
@@ -38,11 +38,14 @@ testsuite.addTests(
     )
 )
 
-# Add a test suite for doctests
+# Include doctests
 testsuite_doctests = unittest.TestSuite()
+# Tell doctest comparisons to treat any sequence of whitespace including
+# newlines as equal and to take '...' in output to mean anything can be there
+doctest_flags = doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS
 for importer, name, ispkg in (
         pkgutil.walk_packages(cfunits.__path__, cfunits.__name__ + '.')):
-    testsuite.addTests(doctest.DocTestSuite(name))
+    testsuite.addTests(doctest.DocTestSuite(name, optionflags=doctest_flags))
 
 
 # Run the test suite.

--- a/cfunits/units.py
+++ b/cfunits/units.py
@@ -519,7 +519,7 @@ class Units:
 
     >>> u = Units('m s-1')
     >>> u
-    <Cf Units: 'm s-1'>
+    <Units: m s-1>
     >>> u.units = 'days since 2004-3-1'
     >>> u
     <Units: days since 2004-3-1>
@@ -622,6 +622,7 @@ class Units:
     place.
 
     >>> u = Units('m')
+    >>> u
     <Units: m>
 
     >>> v = u * 1000
@@ -663,9 +664,12 @@ class Units:
     If the *inplace* keyword is True, then a numpy array is modified
     in place, without any copying overheads:
 
-    >>> Units.conform(a,
-                      Units('days since 2000-12-1'),
-                      Units('days since 2001-1-1'), inplace=True)
+    >>> Units.conform(
+    ...     a,
+    ...     Units('days since 2000-12-1'),
+    ...     Units('days since 2001-1-1'),
+    ...     inplace=True
+    ... )
     array([-31., -30., -29., -28., -27.])
     >>> a
     array([-31., -30., -29., -28., -27.])
@@ -925,8 +929,8 @@ class Units:
 
         >>> u = Units('days since 3-4-5', calendar='gregorian')
         >>> u.__getstate__()
-        {'calendar': 'gregorian',
-         'units': 'days since 3-4-5'}
+        {'_units': 'days since 3-4-5',
+         '_calendar': 'gregorian'}
 
         """
         return dict(
@@ -1621,7 +1625,7 @@ class Units:
         **Examples:**
 
         >>> u = Units('km')
-        >>>  u.isvalid
+        >>> u.isvalid
         True
         >>> u.reason_notvalid
         ''
@@ -1631,12 +1635,11 @@ class Units:
         False
         >>> u.reason_notvalid
         "Invalid units: 'Bad Units'; Not recognised by UDUNITS"
-        >>> u = Units(days since 2000-1-1', calendar='Bad Calendar')
-        >>>  u.isvalid
+        >>> u = Units('days since 2000-1-1', calendar='Bad Calendar')
+        >>> u.isvalid
         False
         >>> u.reason_notvalid
         "Invalid calendar='Bad Calendar'; calendar must be one of ['standard', 'gregorian', 'proleptic_gregorian', 'noleap', 'julian', 'all_leap', '365_day', '366_day', '360_day'], got 'bad calendar'"
-
         """
         return getattr(self, "_isvalid", False)
 
@@ -1662,11 +1665,11 @@ class Units:
         >>> u.reason_notvalid
         "Invalid units: 'Bad Units'; Not recognised by UDUNITS"
 
-        >>> u = Units(days since 2000-1-1', calendar='Bad Calendar')
-        >>>  u.isvalid
+        >>> u = Units('days since 2000-1-1', calendar='Bad Calendar')
+        >>> u.isvalid
         False
         >>> u.reason_notvalid
-        "Invalid calendar='Bad Calendar'; calendar must be one of ['standard', 'gregorian', 'proleptic_gregorian', 'noleap', 'julian', 'all_leap', '365_day', '366_day', '360_day'], got 'bad calendar'"
+        "Invalid calendar='Bad Calendar'"
 
         """
         return getattr(self, "_reason_notvalid", "")
@@ -1685,7 +1688,7 @@ class Units:
 
         >>> u = Units('days since 2001-01-01', calendar='360_day')
         >>> u.reftime
-        cftime.datetime(2001, 1, 1, 0, 0, 0, 0)
+        cftime.datetime(2001, 1, 1, 0, 0, 0, 0, calendar='360_day')
 
         """
         if self.isreftime:
@@ -1798,7 +1801,7 @@ class Units:
 
         >>> u = Units('days since 2000-1-1')
         >>> v = Units('days since 2000-1-1', calendar='366_day')
-        >>> w = Units('seconds since 1978-3-12', calendar='gregorian)
+        >>> w = Units('seconds since 1978-3-12', calendar='gregorian')
 
         >>> u.equivalent(v)
         False
@@ -1953,9 +1956,9 @@ class Units:
 
         >>> u = Units('hours since 2100-1-1', calendar='noleap')
         >>> u.formatted(names=True)
-        'hour since 2100-1-1 00:00:00'
+        'hour since 2100-01-01 00:00:00'
         >>> u.formatted()
-        'h since 2100-1-1 00:00:00'
+        'h since 2100-01-01 00:00:00'
 
         Formatting is also available during object initialization:
 
@@ -2066,9 +2069,12 @@ class Units:
         >>> print(a)
         [ 0.  1.  2.  3.  4.]
 
-        >>> Units.conform(a,
-                          Units('days since 2000-12-1'),
-                          Units('days since 2001-1-1'), inplace=True)
+        >>> Units.conform(
+        ...     a,
+        ...     Units('days since 2000-12-1'),
+        ...     Units('days since 2001-1-1'),
+        ...     inplace=True
+        ... )
         array([-31., -30., -29., -28., -27.])
         >>> print(a)
         [-31. -30. -29. -28. -27.]
@@ -2278,7 +2284,10 @@ class Units:
 
         **Examples:**
 
+        >>> u = Units('decibel')
         >>> v = u.copy()
+        >>> v
+        <Units: decibel>
 
         """
         return self

--- a/cfunits/units.py
+++ b/cfunits/units.py
@@ -520,8 +520,8 @@ class Units:
     >>> u = Units('m s-1')
     >>> u
     <Units: m s-1>
-    >>> u.units = 'days since 2004-3-1'
-    >>> u
+    >>> v = Units('days since 2004-3-1')
+    >>> v
     <Units: days since 2004-3-1>
 
 
@@ -559,10 +559,10 @@ class Units:
     an amount of time since a reference time (*reference time units*):
 
     >>> v = Units()
-    >>> v.units = 's'
-    >>> v.units = 'day'
-    >>> v.units = 'days since 1970-01-01'
-    >>> v.units = 'seconds since 1992-10-8 15:15:42.5 -6:00'
+    >>> v = Units('s')
+    >>> v = Units('day')
+    >>> v = Units('days since 1970-01-01')
+    >>> v = Units('seconds since 1992-10-8 15:15:42.5 -6:00')
 
     .. note:: It is recommended that the units ``year`` and ``month``
               be used with caution, as explained in the following
@@ -588,6 +588,8 @@ class Units:
 
     >>> u = Units('days since 2000-1-1')
     >>> u.calendar
+    Traceback (most recent call last):
+        ...
     AttributeError: Units has no attribute 'calendar'
     >>> v = Units('days since 2000-1-1', 'gregorian')
     >>> v.calendar
@@ -1730,6 +1732,8 @@ class Units:
         >>> Units('days since 2001-1-1', calendar='noleap').calendar
         'noleap'
         >>> Units('days since 2001-1-1').calendar
+        Traceback (most recent call last):
+            ...
         AttributeError: Units has no attribute 'calendar'
 
         """

--- a/cfunits/units.py
+++ b/cfunits/units.py
@@ -659,7 +659,7 @@ class Units:
     >>> Units.conform(a, Units('minute'), Units('second'))
     array([   0.,   60.,  120.,  180.,  240.])
     >>> a
-    array([ 0.,  1.,  2.,  3.,  4.])
+    array([0., 1., 2., 3., 4.])
 
     If the *inplace* keyword is True, then a numpy array is modified
     in place, without any copying overheads:
@@ -2067,7 +2067,7 @@ class Units:
         >>> Units.conform(a, Units('minute'), Units('second'))
         array([   0.,   60.,  120.,  180.,  240.])
         >>> print(a)
-        [ 0.  1.  2.  3.  4.]
+        [0. 1. 2. 3. 4.]
 
         >>> Units.conform(
         ...     a,


### PR DESCRIPTION
Quick PR to setup doctest for cfunits and make appropriate amendments to any code examples as raised by corresponding test failures.

With much thanks to @kinow who provided demonstrated how to do this with cf-python (see NCAS-CMS/cf-python#57) and whose code was largely lifted and shifted here. I thought I'd start with cfunits as a much smaller library to set this up as a POC so that we know how doctest works and any quirks it has, so that can gradually chip away at the docstrings in cfdm and then cf-python to make sure they each set themselves up appropriately (as in NCAS-CMS/cf-python#61) and can therefore be doctested too.

Raising as a draft initially since there are still two doctest failure cases, both relating to `AttributeError`s when trying to set `units` on a `Units` object. I imagine that is deprecated functionality but I just want to check before amending those docstrings.