### PR TITLE
Back in black: format code and set up pre-commit hooks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,17 @@
+# Configure the flake8 code style checker. Note this must be in INI style
+# (see https://flake8.pycqa.org/en/latest/). To run the flake8 checker with
+# this configuration, simply execute 'flake8' under the root of the repo.
+
+[flake8]
+# Ignores should include listing of pycodestyle ignores as in test_style.py
+ignore =
+    E402,
+    E501,
+    E722
+# Exclude these directories/files, otherwise check all *.py files
+exclude =
+    .git,
+    __pycache__,
+    cfunits.egg-info,
+    .pytest_cache,
+    docs/build/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+# Configure pre-commit hooks to check for Python code validity, formatting and
+# style issues and prompt for these to be corrected before committing.
+
+repos:
+
+  # Use specific format-enforcing core pre-commit hooks from the core library
+  # (see pre-commit.com for documentation)
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.4.0
+    hooks:
+      - id: check-ast
+      - id: debug-statements
+      - id: end-of-file-fixer
+        types: [python]
+      - id: trailing-whitespace
+        types: [python]
+
+  # Also validate against 'black' for unambiguous Python formatting
+  # (see https://black.readthedocs.io/en/stable/ for documentation)
+  -   repo: https://github.com/ambv/black
+      rev: stable
+      hooks:
+      - id: black
+        language_version: python3.6
+
+  # Additionally validate againt flake8 for other Python style enforcement
+  # (see https://flake8.pycqa.org/en/latest/ for documentation)
+  -   repo: https://gitlab.com/pycqa/flake8
+      rev: 3.8.3
+      hooks:
+      - id: flake8

--- a/cfunits/__init__.py
+++ b/cfunits/__init__.py
@@ -1,4 +1,4 @@
-'''A Python interface to UNIDATA's UDUNITS-2 package with CF extensions
+"""A Python interface to UNIDATA's UDUNITS-2 package with CF extensions
 
 Store, combine and compare physical units and convert numeric values
 to different units.
@@ -12,13 +12,13 @@ In addition, some units are either new to, modified from, or removed
 from the standard UDUNITS-2 database in order to be more consistent
 with the CF conventions.
 
-'''
+"""
 
-__Conventions__ = 'CF-1.8'
-__author__ = 'David Hassell'
-__date__ = '2020-11-27'
-__version__ = '3.3.1'
-__cf_version__ = '1.8'
+__Conventions__ = "CF-1.8"
+__author__ = "David Hassell"
+__date__ = "2020-11-27"
+__version__ = "3.3.1"
+__cf_version__ = "1.8"
 
 from distutils.version import LooseVersion
 import platform
@@ -29,18 +29,20 @@ except ImportError as error1:
     raise ImportError(error1)
 
 # Check the version of Python
-_minimum_vn = '3.6.0'
+_minimum_vn = "3.6.0"
 if LooseVersion(platform.python_version()) < LooseVersion(_minimum_vn):
     raise RuntimeError(
         "Bad Python version: cfunits requires Python version {} or later. "
-        "Got {}".format(
-            _minimum_vn, platform.python_version()))
+        "Got {}".format(_minimum_vn, platform.python_version())
+    )
 
 # Check the version of cftime
-_minimum_vn = '1.2.1'
+_minimum_vn = "1.2.1"
 if LooseVersion(cftime.__version__) < LooseVersion(_minimum_vn):
     raise ValueError(
         "Bad cftime version: cfunits requires cftime>={}. Got {} at {}".format(
-            _minimum_vn, cftime.__version__, cftime.__file__))
+            _minimum_vn, cftime.__version__, cftime.__file__
+        )
+    )
 
 from .units import Units

--- a/cfunits/__init__.py
+++ b/cfunits/__init__.py
@@ -45,4 +45,4 @@ if LooseVersion(cftime.__version__) < LooseVersion(_minimum_vn):
         )
     )
 
-from .units import Units
+from .units import Units  # noqa: F401

--- a/cfunits/test/.blame-ignore-style-edits
+++ b/cfunits/test/.blame-ignore-style-edits
@@ -1,0 +1,18 @@
+# This file lists commits which were used purely to amend the code style
+# of the codebase. It is designed for use as an option to git blame so that
+# the change history can be seen without the clutter of code style edits
+# (see https://black.readthedocs.io/en/stable/installation_and_usage.html...
+#      ...#migrating-your-code-style-without-ruining-git-blame for example).
+#
+# So instead of 'git blame ...', to ignore formatting edits use (or alias):
+#   git blame --ignore-revs-file .blame-ignore-style-edits
+
+# Commits to make code style abide by vanilla PEP8...
+23e359a39418419a1816776453a0ca6691ac8ef0
+4ecdac8e2cd61a5271159ce9cbc350cac4f45c81
+2cd988351c11528cde74972cd84e0d5612228a2b
+
+# Then commits to further migrate code style to Black...
+f9f9a5e8fb38eeca1b3805ad59e40595ac8bcebd
+4a25de8384df442cd0f84f759feba1ffee6d075c
+740dd16854fba68726594bbe806435c712ba3d1e

--- a/cfunits/test/run_tests.py
+++ b/cfunits/test/run_tests.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import unittest
 import os
-from random import choice, shuffle
+from random import choice
 import sys
 
 import cftime
@@ -10,7 +10,7 @@ import numpy
 import datetime
 import cfunits
 
-from platform import system, platform, python_version
+from platform import platform, python_version
 
 
 def randomise_test_order(*_args):

--- a/cfunits/test/run_tests.py
+++ b/cfunits/test/run_tests.py
@@ -14,13 +14,13 @@ from platform import system, platform, python_version
 
 
 def randomise_test_order(*_args):
-    '''Return a random choice from 1 or -1.
+    """Return a random choice from 1 or -1.
 
     When set as the test loader method for standard (merge)sort comparison
     to order all methods in a test case (see 'sortTestMethodsUsing'), ensures
     they run in a (semi-)random order, meaning implicit reliance on setup or
     state, i.e. test dependencies, should become evident over repeated runs.
-    '''
+    """
     return choice([1, -1])
 
 
@@ -30,8 +30,11 @@ test_loader.sortTestMethodsUsing = randomise_test_order
 
 # Build the test suite from the tests found in the test files.
 testsuite = unittest.TestSuite()
-testsuite.addTests(test_loader().discover(
-    os.path.dirname(os.path.realpath(__file__)), pattern='test_*.py'))
+testsuite.addTests(
+    test_loader().discover(
+        os.path.dirname(os.path.realpath(__file__)), pattern="test_*.py"
+    )
+)
 
 
 # Run the test suite.
@@ -44,19 +47,19 @@ def run_test_suite(verbosity=2):
         exit(1)  # else is zero for sucess as standard
 
 
-if __name__ == '__main__':
-    print('------------------')
-    print('CFUNITS TEST SUITE')
-    print('------------------')
-    print('Run date:', datetime.datetime.now())
-    print('Platform:', str(platform()))
-    print('python:', str(python_version() + ' ' + str(sys.executable)))
-    print('cftime version:', cftime.__version__)
-    print('numpy version:', numpy.__version__)
-    print('cfunits version:', cfunits.__version__)
-    print('cfunits path:', os.path.abspath(cfunits.__file__))
-    print('')
-    print('Running tests from', os.path.abspath(os.curdir))
-    print('')
+if __name__ == "__main__":
+    print("------------------")
+    print("CFUNITS TEST SUITE")
+    print("------------------")
+    print("Run date:", datetime.datetime.now())
+    print("Platform:", str(platform()))
+    print("python:", str(python_version() + " " + str(sys.executable)))
+    print("cftime version:", cftime.__version__)
+    print("numpy version:", numpy.__version__)
+    print("cfunits version:", cfunits.__version__)
+    print("cfunits path:", os.path.abspath(cfunits.__file__))
+    print("")
+    print("Running tests from", os.path.abspath(os.curdir))
+    print("")
 
     run_test_suite()

--- a/cfunits/test/test_Units.py
+++ b/cfunits/test/test_Units.py
@@ -10,331 +10,357 @@ from cfunits import Units
 
 class UnitsTest(unittest.TestCase):
     def test_Units___eq__(self):
-        self.assertEqual(Units(''), Units(''))
-        self.assertEqual(Units('18'), Units('18'))
-        self.assertEqual(Units('1'), Units('1'))
-        self.assertEqual(Units('m'), Units('m'))
-        self.assertEqual(Units('m'), Units('metres'))
-        self.assertEqual(Units('m'), Units('meTRES'))
+        self.assertEqual(Units(""), Units(""))
+        self.assertEqual(Units("18"), Units("18"))
+        self.assertEqual(Units("1"), Units("1"))
+        self.assertEqual(Units("m"), Units("m"))
+        self.assertEqual(Units("m"), Units("metres"))
+        self.assertEqual(Units("m"), Units("meTRES"))
 
-        self.assertEqual(Units('days since 2000-1-1'),
-                         Units('d since 2000-1-1 0:0'))
-        self.assertNotEqual(Units('days since 2000-1-1'),
-                            Units('h since 1234-1-1 0:0'))
+        self.assertEqual(
+            Units("days since 2000-1-1"), Units("d since 2000-1-1 0:0")
+        )
+        self.assertNotEqual(
+            Units("days since 2000-1-1"), Units("h since 1234-1-1 0:0")
+        )
 
-        self.assertEqual(Units('days since 2000-1-1'),
-                         Units('d since 2000-1-1 0:0', calendar='gregorian'))
-        self.assertEqual(Units('days since 2000-1-1'),
-                         Units('d since 2000-1-1 0:0', calendar='standard'))
+        self.assertEqual(
+            Units("days since 2000-1-1"),
+            Units("d since 2000-1-1 0:0", calendar="gregorian"),
+        )
+        self.assertEqual(
+            Units("days since 2000-1-1"),
+            Units("d since 2000-1-1 0:0", calendar="standard"),
+        )
 
-        self.assertEqual(Units(calendar='noleap'), Units(calendar='noleap'))
-        self.assertEqual(Units(calendar='noleap'), Units(calendar='365_day'))
-        self.assertEqual(Units(calendar='nOLEAP'), Units(calendar='365_dAY'))
+        self.assertEqual(Units(calendar="noleap"), Units(calendar="noleap"))
+        self.assertEqual(Units(calendar="noleap"), Units(calendar="365_day"))
+        self.assertEqual(Units(calendar="nOLEAP"), Units(calendar="365_dAY"))
 
-        self.assertEqual(Units('days since 2000-1-1', calendar='all_leap'),
-                         Units('d since 2000-1-1 0:0', calendar='366_day'))
-        self.assertNotEqual(Units('days since 2000-1-1', calendar='all_leap'),
-                            Units('h since 2000-1-1 0:0', calendar='366_day'))
+        self.assertEqual(
+            Units("days since 2000-1-1", calendar="all_leap"),
+            Units("d since 2000-1-1 0:0", calendar="366_day"),
+        )
+        self.assertNotEqual(
+            Units("days since 2000-1-1", calendar="all_leap"),
+            Units("h since 2000-1-1 0:0", calendar="366_day"),
+        )
 
         self.assertNotEqual(Units(1), Units(1))
         self.assertNotEqual(Units(1), Units(2))
         self.assertNotEqual(Units(1), Units())
-        self.assertNotEqual(Units(1), Units(''))
-        self.assertNotEqual(Units(1), Units(' '))
-        self.assertNotEqual(Units(1), Units('metre'))
+        self.assertNotEqual(Units(1), Units(""))
+        self.assertNotEqual(Units(1), Units(" "))
+        self.assertNotEqual(Units(1), Units("metre"))
 
     def test_Units_equivalent(self):
         self.assertTrue(Units().equivalent(Units()))
-        self.assertTrue(Units(' ').equivalent(Units()))
-        self.assertTrue(Units('').equivalent(Units()))
-        self.assertTrue(Units().equivalent(Units('')))
-        self.assertTrue(Units().equivalent(Units(' ')))
-        self.assertTrue(Units('').equivalent(Units('')))
-        self.assertTrue(Units('').equivalent(Units(' ')))
-        self.assertTrue(Units('').equivalent(Units('1')))
-        self.assertTrue(Units('').equivalent(Units('18')))
-        self.assertTrue(Units('18').equivalent(Units('1')))
-        self.assertTrue(Units('18').equivalent(Units('18')))
-        self.assertTrue(Units('1)').equivalent(Units('1')))
+        self.assertTrue(Units(" ").equivalent(Units()))
+        self.assertTrue(Units("").equivalent(Units()))
+        self.assertTrue(Units().equivalent(Units("")))
+        self.assertTrue(Units().equivalent(Units(" ")))
+        self.assertTrue(Units("").equivalent(Units("")))
+        self.assertTrue(Units("").equivalent(Units(" ")))
+        self.assertTrue(Units("").equivalent(Units("1")))
+        self.assertTrue(Units("").equivalent(Units("18")))
+        self.assertTrue(Units("18").equivalent(Units("1")))
+        self.assertTrue(Units("18").equivalent(Units("18")))
+        self.assertTrue(Units("1)").equivalent(Units("1")))
 
-        self.assertTrue(Units('m').equivalent(Units('m')))
-        self.assertTrue(Units('meter').equivalent(Units('km')))
-        self.assertTrue(Units('metre').equivalent(Units('mile')))
+        self.assertTrue(Units("m").equivalent(Units("m")))
+        self.assertTrue(Units("meter").equivalent(Units("km")))
+        self.assertTrue(Units("metre").equivalent(Units("mile")))
 
-        self.assertTrue(Units('s').equivalent(Units('h')))
-        self.assertTrue(Units('s').equivalent(Units('day')))
-        self.assertTrue(Units('second').equivalent(Units('month')))
-
-        self.assertTrue(
-            Units(calendar='noleap').equivalent(Units(calendar='noleap')))
-        self.assertTrue(
-            Units(calendar='noleap').equivalent(Units(calendar='365_day')))
-        self.assertTrue(
-            Units(calendar='nOLEAP').equivalent(Units(calendar='365_dAY')))
+        self.assertTrue(Units("s").equivalent(Units("h")))
+        self.assertTrue(Units("s").equivalent(Units("day")))
+        self.assertTrue(Units("second").equivalent(Units("month")))
 
         self.assertTrue(
-            Units('days since 2000-1-1').equivalent(
-                Units('d since 2000-1-1 0:0'))
+            Units(calendar="noleap").equivalent(Units(calendar="noleap"))
         )
         self.assertTrue(
-            Units('days since 2000-1-1').equivalent(
-                Units('h since 1234-1-1 0:0'))
+            Units(calendar="noleap").equivalent(Units(calendar="365_day"))
         )
         self.assertTrue(
-            Units('days since 2000-1-1').equivalent(
-                Units('d since 2000-1-1 0:0', calendar='gregorian'))
-        )
-        self.assertTrue(
-            Units('days since 2000-1-1').equivalent(
-                Units('h since 1234-1-1 0:0', calendar='standard'))
+            Units(calendar="nOLEAP").equivalent(Units(calendar="365_dAY"))
         )
 
         self.assertTrue(
-            Units('days since 2000-1-1', calendar='all_leap').equivalent(
-                Units('d since 2000-1-1 0:0', calendar='366_day'))
+            Units("days since 2000-1-1").equivalent(
+                Units("d since 2000-1-1 0:0")
+            )
         )
         self.assertTrue(
-            Units('days since 2000-1-1', calendar='all_leap').equivalent(
-                Units('h since 1234-1-1 0:0', calendar='366_day'))
+            Units("days since 2000-1-1").equivalent(
+                Units("h since 1234-1-1 0:0")
+            )
+        )
+        self.assertTrue(
+            Units("days since 2000-1-1").equivalent(
+                Units("d since 2000-1-1 0:0", calendar="gregorian")
+            )
+        )
+        self.assertTrue(
+            Units("days since 2000-1-1").equivalent(
+                Units("h since 1234-1-1 0:0", calendar="standard")
+            )
         )
 
-        u = Units('days since 2000-02-02', calendar='standard')
-        v = Units('months since 2000-02-02', calendar='standard')
+        self.assertTrue(
+            Units("days since 2000-1-1", calendar="all_leap").equivalent(
+                Units("d since 2000-1-1 0:0", calendar="366_day")
+            )
+        )
+        self.assertTrue(
+            Units("days since 2000-1-1", calendar="all_leap").equivalent(
+                Units("h since 1234-1-1 0:0", calendar="366_day")
+            )
+        )
+
+        u = Units("days since 2000-02-02", calendar="standard")
+        v = Units("months since 2000-02-02", calendar="standard")
         self.assertNotEqual(u, v)
 
-        u = Units('days since 2000-02-02', calendar='standard')
-        v = Units('months since 2000-02-02', calendar='gregorian')
+        u = Units("days since 2000-02-02", calendar="standard")
+        v = Units("months since 2000-02-02", calendar="gregorian")
         self.assertNotEqual(u, v)
 
         self.assertFalse(Units(1).equivalent(Units(1)))
         self.assertFalse(Units().equivalent(Units(1)))
         self.assertFalse(Units(2).equivalent(Units(1)))
-        self.assertFalse(Units('').equivalent(Units(1)))
-        self.assertFalse(Units(' ').equivalent(Units(1)))
-        self.assertFalse(Units('1').equivalent(Units(1)))
+        self.assertFalse(Units("").equivalent(Units(1)))
+        self.assertFalse(Units(" ").equivalent(Units(1)))
+        self.assertFalse(Units("1").equivalent(Units(1)))
 
     def test_Units_conform(self):
-        self.assertEqual(Units.conform(0.5, Units('km'), Units('m')), 500)
+        self.assertEqual(Units.conform(0.5, Units("km"), Units("m")), 500)
 
         self.assertEqual(
-            Units.conform(360, Units('second'), Units('minute')), 6)
+            Units.conform(360, Units("second"), Units("minute")), 6
+        )
 
-        x = Units.conform([360], Units('second'), Units('minute'))
+        x = Units.conform([360], Units("second"), Units("minute"))
         self.assertIsInstance(x, numpy.ndarray)
-        self.assertEqual(x.dtype, numpy.dtype('float64'))
+        self.assertEqual(x.dtype, numpy.dtype("float64"))
         self.assertTrue(numpy.allclose(x, 6))
 
-        x = Units.conform((360, 720), Units('second'), Units('minute'))
+        x = Units.conform((360, 720), Units("second"), Units("minute"))
         self.assertIsInstance(x, numpy.ndarray)
-        self.assertEqual(x.dtype, numpy.dtype('float64'))
+        self.assertEqual(x.dtype, numpy.dtype("float64"))
         self.assertTrue(numpy.allclose(x, [6, 12]))
 
-        x = Units.conform([360.0, 720.0], Units('second'), Units('minute'))
+        x = Units.conform([360.0, 720.0], Units("second"), Units("minute"))
         self.assertIsInstance(x, numpy.ndarray)
-        self.assertEqual(x.dtype, numpy.dtype('float64'))
+        self.assertEqual(x.dtype, numpy.dtype("float64"))
         self.assertTrue(numpy.allclose(x, [6, 12]))
 
-        x = Units.conform([[360, 720]], Units('second'), Units('minute'))
+        x = Units.conform([[360, 720]], Units("second"), Units("minute"))
         self.assertIsInstance(x, numpy.ndarray)
-        self.assertEqual(x.dtype, numpy.dtype('float64'))
+        self.assertEqual(x.dtype, numpy.dtype("float64"))
         self.assertTrue(numpy.allclose(x, [[6, 12]]))
 
         v = numpy.array([360.0, 720.0])
-        x = Units.conform(v, Units('second'), Units('minute'))
+        x = Units.conform(v, Units("second"), Units("minute"))
         self.assertIsInstance(x, numpy.ndarray)
-        self.assertEqual(x.dtype, numpy.dtype('float64'))
+        self.assertEqual(x.dtype, numpy.dtype("float64"))
         self.assertTrue(numpy.allclose(x, [6, 12]), x)
 
         v = numpy.array([360, 720])
-        x = Units.conform(v, Units('second'), Units('minute'), inplace=True)
+        x = Units.conform(v, Units("second"), Units("minute"), inplace=True)
         self.assertIsInstance(x, numpy.ndarray)
-        self.assertEqual(x.dtype, numpy.dtype('float64'))
+        self.assertEqual(x.dtype, numpy.dtype("float64"))
         self.assertTrue(numpy.allclose(x, [6, 12]))
         self.assertTrue(numpy.allclose(x, v))
 
-        x = Units.conform(35, Units('degrees_C'), Units('degrees_F'))
+        x = Units.conform(35, Units("degrees_C"), Units("degrees_F"))
         self.assertIsInstance(x, float)
         self.assertTrue(numpy.allclose(x, 95))
 
-        x = Units.conform([35], Units('degrees_C'), Units('degrees_F'))
+        x = Units.conform([35], Units("degrees_C"), Units("degrees_F"))
         self.assertIsInstance(x, numpy.ndarray)
-        self.assertEqual(x.dtype, numpy.dtype('float64'))
+        self.assertEqual(x.dtype, numpy.dtype("float64"))
         self.assertTrue(numpy.allclose(x, 95))
 
-        x = Units.conform(35, Units('degrees_C'), Units('degrees_F'),
-                          inplace=True)
+        x = Units.conform(
+            35, Units("degrees_C"), Units("degrees_F"), inplace=True
+        )
         self.assertIsInstance(x, float)
         self.assertTrue(numpy.allclose(x, 95))
 
-        x = Units.conform([35], Units('degrees_C'), Units('degrees_F'),
-                          inplace=True)
+        x = Units.conform(
+            [35], Units("degrees_C"), Units("degrees_F"), inplace=True
+        )
         self.assertIsInstance(x, numpy.ndarray)
-        self.assertEqual(x.dtype, numpy.dtype('float64'))
+        self.assertEqual(x.dtype, numpy.dtype("float64"))
         self.assertTrue(numpy.allclose(x, 95))
 
         with self.assertRaises(ValueError):
-            Units.conform(1, Units('m'), Units('second'))
+            Units.conform(1, Units("m"), Units("second"))
 
     def test_Units_BINARY_AND_UNARY_OPERATORS(self):
-        self.assertEqual(Units('m') * 2, Units('2m'))
-        self.assertEqual(Units('m') / 2, Units('0.5m'))
-        self.assertEqual(Units('m') // 2, Units('0.5m'))
-        self.assertEqual(Units('m') + 2, Units('m @ -2'))
-        self.assertEqual(Units('m') - 2, Units('m @ 2'))
-        self.assertEqual(Units('m') ** 2, Units('m2'))
-        self.assertEqual(Units('m') ** -2, Units('m-2'))
-        self.assertEqual(Units('m2') ** 0.5, Units('m'))
+        self.assertEqual(Units("m") * 2, Units("2m"))
+        self.assertEqual(Units("m") / 2, Units("0.5m"))
+        self.assertEqual(Units("m") // 2, Units("0.5m"))
+        self.assertEqual(Units("m") + 2, Units("m @ -2"))
+        self.assertEqual(Units("m") - 2, Units("m @ 2"))
+        self.assertEqual(Units("m") ** 2, Units("m2"))
+        self.assertEqual(Units("m") ** -2, Units("m-2"))
+        self.assertEqual(Units("m2") ** 0.5, Units("m"))
 
-        u = Units('m')
+        u = Units("m")
         v = u
         u *= 2
-        self.assertEqual(u, Units('2m'))
+        self.assertEqual(u, Units("2m"))
         self.assertNotEqual(u, v)
-        u = Units('m')
+        u = Units("m")
         v = u
         u /= 2
-        self.assertEqual(u, Units('0.5m'))
+        self.assertEqual(u, Units("0.5m"))
         self.assertNotEqual(u, v)
-        u = Units('m')
+        u = Units("m")
         v = u
         u //= 2
-        self.assertEqual(u, Units('0.5m'))
+        self.assertEqual(u, Units("0.5m"))
         self.assertNotEqual(u, v)
-        u = Units('m')
+        u = Units("m")
         v = u
         u += 2
-        self.assertEqual(u, Units('m @ -2'))
+        self.assertEqual(u, Units("m @ -2"))
         self.assertNotEqual(u, v)
-        u = Units('m')
+        u = Units("m")
         v = u
         u -= 2
-        self.assertEqual(u, Units('m @ 2'))
+        self.assertEqual(u, Units("m @ 2"))
         self.assertNotEqual(u, v)
-        u = Units('m')
+        u = Units("m")
         v = u
         u **= 2
-        self.assertEqual(u, Units('m2'))
+        self.assertEqual(u, Units("m2"))
         self.assertNotEqual(u, v)
 
-        self.assertEqual(2 * Units('m'), Units('2m'))
-        self.assertEqual(2 / Units('m'), Units('2 m-1'))
-        self.assertEqual(2 // Units('m'), Units('2 m-1'))
-        self.assertEqual(2 + Units('m'), Units('m @ -2'))
-        self.assertEqual(2 - Units('m'), Units('-1 m @ -2'))
+        self.assertEqual(2 * Units("m"), Units("2m"))
+        self.assertEqual(2 / Units("m"), Units("2 m-1"))
+        self.assertEqual(2 // Units("m"), Units("2 m-1"))
+        self.assertEqual(2 + Units("m"), Units("m @ -2"))
+        self.assertEqual(2 - Units("m"), Units("-1 m @ -2"))
 
-        self.assertEqual(Units('m') * Units('2m'), Units('2 m2'))
-        self.assertEqual(Units('m') / Units('2m'), Units('0.5'))
-        self.assertEqual(Units('m') // Units('2m'), Units('0.5'))
+        self.assertEqual(Units("m") * Units("2m"), Units("2 m2"))
+        self.assertEqual(Units("m") / Units("2m"), Units("0.5"))
+        self.assertEqual(Units("m") // Units("2m"), Units("0.5"))
 
-        u = Units('m')
+        u = Units("m")
         v = u
         u *= u
-        self.assertEqual(u, Units('m2'))
+        self.assertEqual(u, Units("m2"))
         self.assertNotEqual(u, v)
-        u = Units('m')
+        u = Units("m")
         v = u
         u /= u
-        self.assertEqual(u, Units('1'))
+        self.assertEqual(u, Units("1"))
         self.assertNotEqual(u, v)
-        u = Units('m')
+        u = Units("m")
         v = u
         u //= u
-        self.assertEqual(u, Units('1'))
+        self.assertEqual(u, Units("1"))
         self.assertNotEqual(u, v)
 
-        self.assertEqual(Units('m').log(10), Units('lg(re 1 m)'))
-        self.assertEqual(Units('m').log(2), Units('lb(re 1 m)'))
-        self.assertEqual(Units('m').log(math.e), Units('ln(re 1 m)'))
-        self.assertEqual(Units('m').log(1.5),
-                         Units('2.46630346237643 ln(re 1 m)'))
+        self.assertEqual(Units("m").log(10), Units("lg(re 1 m)"))
+        self.assertEqual(Units("m").log(2), Units("lb(re 1 m)"))
+        self.assertEqual(Units("m").log(math.e), Units("ln(re 1 m)"))
+        self.assertEqual(
+            Units("m").log(1.5), Units("2.46630346237643 ln(re 1 m)")
+        )
 
     def test_Units_isvalid(self):
-        self.assertTrue(Units('m').isvalid)
-        self.assertTrue(Units('days since 2019-01-01').isvalid)
+        self.assertTrue(Units("m").isvalid)
+        self.assertTrue(Units("days since 2019-01-01").isvalid)
         self.assertTrue(
-            Units('days since 2019-01-01', calendar='360_day').isvalid)
+            Units("days since 2019-01-01", calendar="360_day").isvalid
+        )
 
-        self.assertFalse(Units('qwerty').isvalid)
+        self.assertFalse(Units("qwerty").isvalid)
         self.assertFalse(Units(1.0).isvalid)
-        self.assertFalse(Units([1.0, 'qwerty']).isvalid)
-        self.assertFalse(Units('since 2019-01-01').isvalid)
+        self.assertFalse(Units([1.0, "qwerty"]).isvalid)
+        self.assertFalse(Units("since 2019-01-01").isvalid)
         self.assertFalse(
-            Units('days since 2019-01-01', calendar='qwerty').isvalid)
-        self.assertFalse(
-            Units('since 2019-01-01', calendar='qwerty').isvalid)
+            Units("days since 2019-01-01", calendar="qwerty").isvalid
+        )
+        self.assertFalse(Units("since 2019-01-01", calendar="qwerty").isvalid)
 
     def test_Units_has_offset(self):
-        self.assertFalse(Units('K').has_offset)
-        self.assertFalse(Units('K @ 0').has_offset)
-        self.assertFalse(Units('Watt').has_offset)
-        self.assertFalse(Units('m2.kg.s-3').has_offset)
-        self.assertFalse(Units('km').has_offset)
-        self.assertFalse(Units('1000 m').has_offset)
-        self.assertFalse(Units('(K @ 273.15) m s-1').has_offset)
-        self.assertFalse(Units('degC m s-1').has_offset)
+        self.assertFalse(Units("K").has_offset)
+        self.assertFalse(Units("K @ 0").has_offset)
+        self.assertFalse(Units("Watt").has_offset)
+        self.assertFalse(Units("m2.kg.s-3").has_offset)
+        self.assertFalse(Units("km").has_offset)
+        self.assertFalse(Units("1000 m").has_offset)
+        self.assertFalse(Units("(K @ 273.15) m s-1").has_offset)
+        self.assertFalse(Units("degC m s-1").has_offset)
 
-        self.assertTrue(Units('K @ 273.15').has_offset)
-        self.assertTrue(Units('degC').has_offset)
-        self.assertTrue(Units('degF').has_offset)
-        self.assertTrue(Units('m2.kg.s-3 @ 3.14').has_offset)
+        self.assertTrue(Units("K @ 273.15").has_offset)
+        self.assertTrue(Units("degC").has_offset)
+        self.assertTrue(Units("degF").has_offset)
+        self.assertTrue(Units("m2.kg.s-3 @ 3.14").has_offset)
 
-        self.assertEqual(Units('degC m s-1'), Units('K m s-1'))
+        self.assertEqual(Units("degC m s-1"), Units("K m s-1"))
 
     def test_Units__hash__(self):
-        self.assertIsInstance(hash(Units('K')), int)
-        self.assertIsInstance(hash(Units('')), int)
+        self.assertIsInstance(hash(Units("K")), int)
+        self.assertIsInstance(hash(Units("")), int)
         self.assertIsInstance(hash(Units()), int)
-        self.assertIsInstance(hash(Units('days since 2000-01-01')), int)
-        self.assertIsInstance(hash(Units('days since 2000-01-01',
-                                         calendar='360_day')),
-                              int)
+        self.assertIsInstance(hash(Units("days since 2000-01-01")), int)
+        self.assertIsInstance(
+            hash(Units("days since 2000-01-01", calendar="360_day")), int
+        )
 
     def test_Units_formatted(self):
-        u = Units('W')
-        self.assertEqual(u.units, 'W')
-        self.assertEqual(u.formatted(names=True), 'watt')
-        self.assertEqual(u.formatted(definition=True), 'm2.kg.s-3')
+        u = Units("W")
+        self.assertEqual(u.units, "W")
+        self.assertEqual(u.formatted(names=True), "watt")
+        self.assertEqual(u.formatted(definition=True), "m2.kg.s-3")
         self.assertEqual(
             u.formatted(names=True, definition=True),
-            'meter^2-kilogram-second^-3'
+            "meter^2-kilogram-second^-3",
         )
-        self.assertEqual(u.formatted(), 'W')
+        self.assertEqual(u.formatted(), "W")
 
-        u = Units('tsp')
-        self.assertEqual(u.formatted(names=True), '4.928921875e-06 meter^3')
-        u = Units('tsp', names=True)
-        self.assertEqual(u.units, '4.928921875e-06 meter^3')
+        u = Units("tsp")
+        self.assertEqual(u.formatted(names=True), "4.928921875e-06 meter^3")
+        u = Units("tsp", names=True)
+        self.assertEqual(u.units, "4.928921875e-06 meter^3")
 
-        u = Units('m/s', formatted=True)
-        self.assertEqual(u.units, 'm.s-1')
+        u = Units("m/s", formatted=True)
+        self.assertEqual(u.units, "m.s-1")
 
-        u = Units('Watt', formatted=True)
-        self.assertEqual(u.units, 'W')
-        u = Units('Watt', names=True)
-        self.assertEqual(u.units, 'watt')
-        u = Units('Watt', definition=True)
-        self.assertEqual(u.units, 'm2.kg.s-3')
-        u = Units('Watt', names=True, definition=True)
-        self.assertEqual(u.units, 'meter^2-kilogram-second^-3')
+        u = Units("Watt", formatted=True)
+        self.assertEqual(u.units, "W")
+        u = Units("Watt", names=True)
+        self.assertEqual(u.units, "watt")
+        u = Units("Watt", definition=True)
+        self.assertEqual(u.units, "m2.kg.s-3")
+        u = Units("Watt", names=True, definition=True)
+        self.assertEqual(u.units, "meter^2-kilogram-second^-3")
 
-        u = Units('days since 1900-1-1 03:05', names=True)
-        self.assertEqual(u.units, 'day since 1900-01-01 03:05:00')
-        u = Units('days since 1900-1-1 03:05', formatted=True)
-        self.assertEqual(u.units, 'd since 1900-01-01 03:05:00')
-        u = Units('days since 1900-1-1 03:05')
-        self.assertEqual(u.formatted(), 'd since 1900-01-01 03:05:00')
+        u = Units("days since 1900-1-1 03:05", names=True)
+        self.assertEqual(u.units, "day since 1900-01-01 03:05:00")
+        u = Units("days since 1900-1-1 03:05", formatted=True)
+        self.assertEqual(u.units, "d since 1900-01-01 03:05:00")
+        u = Units("days since 1900-1-1 03:05")
+        self.assertEqual(u.formatted(), "d since 1900-01-01 03:05:00")
 
-        u = Units('hours since 2100-1-1', calendar='noleap', names=True)
-        self.assertEqual(u.units, 'hour since 2100-01-01 00:00:00')
-        u = Units('hours since 2100-1-1', calendar='noleap', formatted=True)
-        self.assertEqual(u.units, 'h since 2100-01-01 00:00:00')
-        u = Units('hours since 2100-1-1', calendar='noleap')
-        self.assertEqual(u.formatted(), 'h since 2100-01-01 00:00:00')
+        u = Units("hours since 2100-1-1", calendar="noleap", names=True)
+        self.assertEqual(u.units, "hour since 2100-01-01 00:00:00")
+        u = Units("hours since 2100-1-1", calendar="noleap", formatted=True)
+        self.assertEqual(u.units, "h since 2100-01-01 00:00:00")
+        u = Units("hours since 2100-1-1", calendar="noleap")
+        self.assertEqual(u.formatted(), "h since 2100-01-01 00:00:00")
+
+
 # --- End: class
 
 
-if __name__ == '__main__':
-    print('cfunits version:', cfunits.__version__)
-    print('cfunits path:', os.path.abspath(cfunits.__file__))
-    print('')
+if __name__ == "__main__":
+    print("cfunits version:", cfunits.__version__)
+    print("cfunits path:", os.path.abspath(cfunits.__file__))
+    print("")
     unittest.main(verbosity=2)

--- a/cfunits/test/test_style.py
+++ b/cfunits/test/test_style.py
@@ -8,6 +8,7 @@ import cfunits
 
 class styleTest(unittest.TestCase):
     """Test PEP8 compliance on all '.py' files in the 'cfunits' directory."""
+
     def setUp(self):
         self.cfunits_dir = os.path.dirname(os.path.abspath(__file__))
         os.chdir(self.cfunits_dir)
@@ -16,41 +17,41 @@ class styleTest(unittest.TestCase):
         pep8_check = pycodestyle.StyleGuide()
 
         # Directories to skip in the recursive walk of the directory:
-        skip_dirs = (
-            '__pycache__',
-        )
+        skip_dirs = ("__pycache__",)
         # These are pycodestyle errors and warnings to explicitly ignore. For
         # descriptions for each code see:
         # https://pep8.readthedocs.io/en/latest/intro.html#error-codes
         pep8_check.options.ignore += (  # ignored because...
-            'E402',  # ...justified lower module imports in __init__ and units
-            'E501',  # ...docstring examples include output lines >79 chars
-            'E722',  # ...several "bare except" cases need to be addressed
+            "E402",  # ...justified lower module imports in __init__ and units
+            "E501",  # ...docstring examples include output lines >79 chars
+            "E722",  # ...several "bare except" cases need to be addressed
         )
 
         # Find all Python source code ('.py') files in the 'cfunits' directory,
         # including all unskipped sub-directories within e.g. test directory:
         python_files = []
-        for root_dir, dirs, filelist in os.walk('..'):  # '..' == 'cfunits/'
+        for root_dir, dirs, filelist in os.walk(".."):  # '..' == 'cfunits/'
             if os.path.basename(root_dir) in skip_dirs:
                 continue
             python_files += [
-                os.path.join(root_dir, fname) for fname in filelist
-                if fname.endswith('.py')
+                os.path.join(root_dir, fname)
+                for fname in filelist
+                if fname.endswith(".py")
             ]
 
         pep8_issues = pep8_check.check_files(python_files).total_errors
         self.assertEqual(
-            pep8_issues, 0,
-            'Detected {!s} PEP8 errors or warnings:'.format(pep8_issues)
+            pep8_issues,
+            0,
+            "Detected {!s} PEP8 errors or warnings:".format(pep8_issues),
         )
 
 
 # --- End: class
 
 
-if __name__ == '__main__':
-    print('cfunits version:', cfunits.__version__)
-    print('cfunits path:', os.path.abspath(cfunits.__file__))
-    print('')
+if __name__ == "__main__":
+    print("cfunits version:", cfunits.__version__)
+    print("cfunits path:", os.path.abspath(cfunits.__file__))
+    print("")
     unittest.main(verbosity=2)

--- a/cfunits/test/test_style.py
+++ b/cfunits/test/test_style.py
@@ -1,4 +1,3 @@
-import datetime
 import os
 import pycodestyle
 import unittest

--- a/cfunits/units.py
+++ b/cfunits/units.py
@@ -30,8 +30,7 @@ _c_void_p = ctypes.c_void_p
 _pointer = ctypes.pointer
 _POINTER = ctypes.POINTER
 
-_ctypes_POINTER = {4: _POINTER(_c_float),
-                   8: _POINTER(_c_double)}
+_ctypes_POINTER = {4: _POINTER(_c_float), 8: _POINTER(_c_double)}
 
 # --------------------------------------------------------------------
 # Load the Udunits-2 library and read the database
@@ -42,7 +41,7 @@ _ctypes_POINTER = {4: _POINTER(_c_float),
 # else:
 #     # Linux
 #     _udunits = ctypes.CDLL('libudunits2.so.0')
-_libpath = ctypes.util.find_library('udunits2')
+_libpath = ctypes.util.find_library("udunits2")
 if _libpath is None:
     raise FileNotFoundError(
         "cfunits requires UNIDATA UDUNITS-2. Can't find the 'udunits2' "
@@ -59,7 +58,7 @@ _udunits = ctypes.CDLL(_libpath)
 # ut_error_message_handler ut_set_error_message_handler(
 #                                   ut_error_message_handler handler);
 _ut_set_error_message_handler = _udunits.ut_set_error_message_handler
-_ut_set_error_message_handler.argtypes = (_c_void_p, )
+_ut_set_error_message_handler.argtypes = (_c_void_p,)
 _ut_set_error_message_handler.restype = _c_void_p
 
 _ut_set_error_message_handler(_udunits.ut_ignore)
@@ -67,7 +66,7 @@ _ut_set_error_message_handler(_udunits.ut_ignore)
 # Read the data base
 # ut_system* ut_read_xml(const char* path);
 _ut_read_xml = _udunits.ut_read_xml
-_ut_read_xml.argtypes = (_c_char_p, )
+_ut_read_xml.argtypes = (_c_char_p,)
 _ut_read_xml.restype = _c_void_p
 
 # print('units: before _udunits.ut_read_xml(',_unit_database,')')
@@ -163,7 +162,7 @@ _ut_root.restype = _c_void_p
 
 # void ut_free_system(ut_system*  system);
 _ut_free = _udunits.ut_free
-_ut_free.argypes = (_c_void_p, )
+_ut_free.argypes = (_c_void_p,)
 _ut_free.restype = None
 
 # float* cv_convert_floats(const cv_converter* converter, const float*
@@ -187,15 +186,14 @@ _cv_convert_double.restype = _c_double
 
 # void cv_free(cv_converter* const conv);
 _cv_free = _udunits.cv_free
-_cv_free.argtypes = (_c_void_p, )
+_cv_free.argtypes = (_c_void_p,)
 _cv_free.restype = None
 
 _UT_ASCII = 0
 _UT_NAMES = 4
 _UT_DEFINITION = 8
 
-_cv_convert_array = {4: _cv_convert_floats,
-                     8: _cv_convert_doubles}
+_cv_convert_array = {4: _cv_convert_floats, 8: _cv_convert_doubles}
 
 # Some function definitions necessary for the following
 # changes to the unit system.
@@ -220,7 +218,7 @@ _ut_map_unit_to_name = _udunits.ut_map_unit_to_name
 _ut_map_unit_to_name.argtypes = (_c_void_p, _c_char_p, _c_int)
 _ut_map_unit_to_name.restype = _c_int
 _ut_new_base_unit = _udunits.ut_new_base_unit
-_ut_new_base_unit.argtypes = (_c_void_p, )
+_ut_new_base_unit.argtypes = (_c_void_p,)
 _ut_new_base_unit.restype = _c_void_p
 
 # Change Sv mapping. Both sievert and sverdrup are just aliases,
@@ -229,44 +227,54 @@ _ut_new_base_unit.restype = _c_void_p
 # the correct sievert mapping in place; because that mapping
 # was only an alias, the unit now doesn't depend on the mapping
 # persisting.
-assert(0 == _ut_unmap_symbol_to_unit(_ut_system, _c_char_p(b'Sv'), _UT_ASCII))
-assert(0 == _ut_map_symbol_to_unit(
-    _c_char_p(b'Sv'),
+assert 0 == _ut_unmap_symbol_to_unit(_ut_system, _c_char_p(b"Sv"), _UT_ASCII)
+assert 0 == _ut_map_symbol_to_unit(
+    _c_char_p(b"Sv"),
     _UT_ASCII,
-    _ut_get_unit_by_name(_ut_system, _c_char_p(b'sverdrup'))
-))
+    _ut_get_unit_by_name(_ut_system, _c_char_p(b"sverdrup")),
+)
 
 # Add new base unit calendar_year
 calendar_year_unit = _ut_new_base_unit(_ut_system)
-assert(0 == _ut_map_symbol_to_unit(
-    _c_char_p(b'cY'), _UT_ASCII, calendar_year_unit))
-assert(0 == _ut_map_unit_to_symbol(
-    calendar_year_unit, _c_char_p(b'cY'), _UT_ASCII))
-assert(0 == _ut_map_name_to_unit(
-    _c_char_p(b'calendar_year'), _UT_ASCII, calendar_year_unit))
-assert(0 == _ut_map_unit_to_name(
-    calendar_year_unit, _c_char_p(b'calendar_year'), _UT_ASCII))
-assert(0 == _ut_map_name_to_unit(
-    _c_char_p(b'calendar_years'), _UT_ASCII, calendar_year_unit))
+assert 0 == _ut_map_symbol_to_unit(
+    _c_char_p(b"cY"), _UT_ASCII, calendar_year_unit
+)
+assert 0 == _ut_map_unit_to_symbol(
+    calendar_year_unit, _c_char_p(b"cY"), _UT_ASCII
+)
+assert 0 == _ut_map_name_to_unit(
+    _c_char_p(b"calendar_year"), _UT_ASCII, calendar_year_unit
+)
+assert 0 == _ut_map_unit_to_name(
+    calendar_year_unit, _c_char_p(b"calendar_year"), _UT_ASCII
+)
+assert 0 == _ut_map_name_to_unit(
+    _c_char_p(b"calendar_years"), _UT_ASCII, calendar_year_unit
+)
 
 
 # Add various aliases useful for CF
 def add_unit_alias(definition, symbol, singular, plural):
     unit = _ut_parse(
-        _ut_system, _c_char_p(definition.encode('utf-8')), _UT_ASCII)
+        _ut_system, _c_char_p(definition.encode("utf-8")), _UT_ASCII
+    )
     if symbol is not None:
-        assert(0 == _ut_map_symbol_to_unit(
-            _c_char_p(symbol.encode('utf-8')), _UT_ASCII, unit))
+        assert 0 == _ut_map_symbol_to_unit(
+            _c_char_p(symbol.encode("utf-8")), _UT_ASCII, unit
+        )
     if singular is not None:
-        assert(0 == _ut_map_name_to_unit(
-            _c_char_p(singular.encode('utf-8')), _UT_ASCII, unit))
+        assert 0 == _ut_map_name_to_unit(
+            _c_char_p(singular.encode("utf-8")), _UT_ASCII, unit
+        )
     if plural is not None:
-        assert(0 == _ut_map_name_to_unit(
-            _c_char_p(plural.encode('utf-8')), _UT_ASCII, unit))
+        assert 0 == _ut_map_name_to_unit(
+            _c_char_p(plural.encode("utf-8")), _UT_ASCII, unit
+        )
 
 
 add_unit_alias(
-    "1.e-3", "psu", "practical_salinity_unit", "practical_salinity_units")
+    "1.e-3", "psu", "practical_salinity_unit", "practical_salinity_units"
+)
 add_unit_alias("calendar_year/12", "cM", "calendar_month", "calendar_months")
 add_unit_alias("1", None, "level", "levels")
 add_unit_alias("1", None, "layer", "layers")
@@ -287,6 +295,7 @@ add_unit_alias("10 dB", None, "bel", "bels")
 # Aliases for netCDF4.netcdftime classes
 # --------------------------------------------------------------------
 import cftime
+
 # _netCDF4_netcdftime_utime = cftime.utime
 # _datetime                 = cftime.datetime
 
@@ -303,42 +312,43 @@ _cached_utime = {}
 # Save some useful units
 # --------------------------------------------------------------------
 # A time ut_unit (equivalent to 'day', 'second', etc.)
-_day_ut_unit = _ut_parse(_ut_system, _c_char_p(b'day'), _UT_ASCII)
-_cached_ut_unit['days'] = _day_ut_unit
+_day_ut_unit = _ut_parse(_ut_system, _c_char_p(b"day"), _UT_ASCII)
+_cached_ut_unit["days"] = _day_ut_unit
 # A pressure ut_unit (equivalent to 'Pa', 'hPa', etc.)
-_pressure_ut_unit = _ut_parse(_ut_system, _c_char_p(b'pascal'), _UT_ASCII)
-_cached_ut_unit['pascal'] = _pressure_ut_unit
+_pressure_ut_unit = _ut_parse(_ut_system, _c_char_p(b"pascal"), _UT_ASCII)
+_cached_ut_unit["pascal"] = _pressure_ut_unit
 # A calendar time ut_unit (equivalent to 'cY', 'cM')
 _calendartime_ut_unit = _ut_parse(
-    _ut_system, _c_char_p(b'calendar_year'), _UT_ASCII)
-_cached_ut_unit['calendar_year'] = _calendartime_ut_unit
+    _ut_system, _c_char_p(b"calendar_year"), _UT_ASCII
+)
+_cached_ut_unit["calendar_year"] = _calendartime_ut_unit
 # A dimensionless unit one (equivalent to '', '1', '2', etc.)
 # _dimensionless_unit_one = _udunits.ut_get_dimensionless_unit_one(_ut_system)
 # _cached_ut_unit['']  = _dimensionless_unit_one
 # _cached_ut_unit['1'] = _dimensionless_unit_one
 
-_dimensionless_unit_one = _ut_parse(_ut_system, _c_char_p(b'1'), _UT_ASCII)
-_cached_ut_unit[''] = _dimensionless_unit_one
-_cached_ut_unit['1'] = _dimensionless_unit_one
+_dimensionless_unit_one = _ut_parse(_ut_system, _c_char_p(b"1"), _UT_ASCII)
+_cached_ut_unit[""] = _dimensionless_unit_one
+_cached_ut_unit["1"] = _dimensionless_unit_one
 
 # --------------------------------------------------------------------
 # Set the default calendar type according to the CF conventions
 # --------------------------------------------------------------------
-_default_calendar = 'gregorian'
+_default_calendar = "gregorian"
 _canonical_calendar = {
-    'gregorian': 'gregorian',
-    'standard': 'gregorian',
-    'none': 'gregorian',
-    'proleptic_gregorian': 'proleptic_gregorian',
-    '360_day': '360_day',
-    'noleap': '365_day',
-    '365_day': '365_day',
-    'all_leap': '366_day',
-    '366_day': '366_day',
-    'julian': 'julian',
+    "gregorian": "gregorian",
+    "standard": "gregorian",
+    "none": "gregorian",
+    "proleptic_gregorian": "proleptic_gregorian",
+    "360_day": "360_day",
+    "noleap": "365_day",
+    "365_day": "365_day",
+    "all_leap": "366_day",
+    "366_day": "366_day",
+    "julian": "julian",
 }
 
-_months_or_years = ('month', 'months', 'year', 'years', 'yr')
+_months_or_years = ("month", "months", "year", "years", "yr")
 
 # # --------------------------------------------------------------------
 # # Set month lengths in days for non-leap years (_days_in_month[0,1:])
@@ -353,7 +363,7 @@ _months_or_years = ('month', 'months', 'year', 'years', 'yr')
 # Function to control Udunits error messages
 # --------------------------------------------------------------------
 def udunits_error_messages(flag):
-    '''Control the printing of error messages from Udunits, which are
+    """Control the printing of error messages from Udunits, which are
     turned off by default.
 
     :Parameters:
@@ -371,11 +381,12 @@ def udunits_error_messages(flag):
     >>> udunits_error_messages(True)
     >>> udunits_error_messages(False)
 
-    '''
+    """
     if flag:
         _ut_set_error_message_handler(_udunits.ut_write_to_stderr)
     else:
         _ut_set_error_message_handler(_udunits.ut_ignore)
+
 
 # def _month_length(year, month, calendar, _days_in_month=_days_in_month):
 #     '''
@@ -467,8 +478,8 @@ _year_length = 365.242198781
 _month_length = _year_length / 12
 
 
-class Units():
-    '''Store, combine and compare physical units and convert numeric
+class Units:
+    """Store, combine and compare physical units and convert numeric
     values to different units.
 
     Units are as defined in UNIDATA's Udunits-2 package, with a few
@@ -663,45 +674,53 @@ class Units():
     >>> a
     array([-31., -30., -29., -28., -27.])
 
-    '''
-    def __init__(self, units=None, calendar=None, formatted=False,
-                 names=False, definition=False, _ut_unit=None):
-        '''**Initialization**
+    """
 
-    :Parameters:
+    def __init__(
+        self,
+        units=None,
+        calendar=None,
+        formatted=False,
+        names=False,
+        definition=False,
+        _ut_unit=None,
+    ):
+        """**Initialization**
 
-        units: `str` or `Units`, optional
-            Set the new units from this string.
+        :Parameters:
 
-        calendar: `str`, optional
-            Set the calendar for reference time units.
+            units: `str` or `Units`, optional
+                Set the new units from this string.
 
-        formatted: `bool`, optional
-            Format the string representation of the units in a
-            standardized manner. See the `formatted` method.
+            calendar: `str`, optional
+                Set the calendar for reference time units.
 
-        names: `bool`, optional
-            Format the string representation of the units using names
-            instead of symbols. See the `formatted` method.
+            formatted: `bool`, optional
+                Format the string representation of the units in a
+                standardized manner. See the `formatted` method.
 
-        definition: `bool`, optional
-            Format the string representation of the units using basic
-            units. See the `formatted` method.
+            names: `bool`, optional
+                Format the string representation of the units using names
+                instead of symbols. See the `formatted` method.
 
-        _ut_unit: `int`, optional
-            Set the new units from this Udunits binary unit
-            representation. This should be an integer returned by a
-            call to `ut_parse` function of Udunits. Ignored if *units*
-            is set.
+            definition: `bool`, optional
+                Format the string representation of the units using basic
+                units. See the `formatted` method.
 
-        '''
+            _ut_unit: `int`, optional
+                Set the new units from this Udunits binary unit
+                representation. This should be an integer returned by a
+                call to `ut_parse` function of Udunits. Ignored if *units*
+                is set.
+
+        """
 
         if isinstance(units, self.__class__):
             self.__dict__ = units.__dict__
             return
 
         self._isvalid = True
-        self._reason_notvalid = ''
+        self._reason_notvalid = ""
         self._units = units
         self._ut_unit = None
         self._isreftime = False
@@ -716,7 +735,8 @@ class Units():
             _calendar = _canonical_calendar.get(calendar.lower())
             if _calendar is None:
                 self._new_reason_notvalid(
-                    "Invalid calendar={!r}".format(calendar))
+                    "Invalid calendar={!r}".format(calendar)
+                )
                 self._isvalid = False
                 _calendar = calendar
         # --- End: if
@@ -727,12 +747,13 @@ class Units():
             except AttributeError:
                 self._isvalid = False
                 self._new_reason_notvalid(
-                    "Bad units type: {}".format(type(units)))
+                    "Bad units type: {}".format(type(units))
+                )
                 return
 
             unit = None
 
-            if isinstance(units, str) and ' since ' in units:
+            if isinstance(units, str) and " since " in units:
                 # ----------------------------------------------------
                 # Set a reference time unit
                 # ----------------------------------------------------
@@ -745,17 +766,19 @@ class Units():
                         _calendar = calendar
                 # --- End: if
 
-                units_split = units.split(' since ')
+                units_split = units.split(" since ")
                 unit = units_split[0].strip()
 
                 _units_since_reftime = unit
 
                 ut_unit = _cached_ut_unit.get(unit, None)
                 if ut_unit is None:
-                    ut_unit = _ut_parse(_ut_system, _c_char_p(
-                        unit.encode('utf-8')), _UT_ASCII)
+                    ut_unit = _ut_parse(
+                        _ut_system, _c_char_p(unit.encode("utf-8")), _UT_ASCII
+                    )
                     if not ut_unit or not _ut_are_convertible(
-                            ut_unit, _day_ut_unit):
+                        ut_unit, _day_ut_unit
+                    ):
                         ut_unit = None
                         self._isvalid = False
                     else:
@@ -768,8 +791,9 @@ class Units():
                     utime = _cached_utime[(_calendar, units)]
                 else:
                     # Create a new Utime object
-                    unit_string = '{} since {}'.format(
-                        unit, units_split[1].strip())
+                    unit_string = "{} since {}".format(
+                        unit, units_split[1].strip()
+                    )
 
                     if (_calendar, unit_string) in _cached_utime:
                         utime = _cached_utime[(_calendar, unit_string)]
@@ -779,8 +803,9 @@ class Units():
                         except Exception as error:
                             utime = None
                             if unit in _months_or_years:
-                                temp_unit_string = 'days since {}'.format(
-                                    units_split[1].strip())
+                                temp_unit_string = "days since {}".format(
+                                    units_split[1].strip()
+                                )
                                 try:
                                     _ = Utime(_calendar, temp_unit_string)
                                 except Exception as error:
@@ -805,28 +830,29 @@ class Units():
                 # ----------------------------------------------------
                 ut_unit = _cached_ut_unit.get(units, None)
                 if ut_unit is None:
-                    ut_unit = _ut_parse(_ut_system,
-                                        _c_char_p(units.encode('utf-8')),
-                                        _UT_ASCII)
+                    ut_unit = _ut_parse(
+                        _ut_system, _c_char_p(units.encode("utf-8")), _UT_ASCII
+                    )
                     if not ut_unit:
                         ut_unit = None
                         self._isvalid = False
                         self._new_reason_notvalid(
                             "Invalid units: {!r}; "
-                            "Not recognised by UDUNITS".format(units))
+                            "Not recognised by UDUNITS".format(units)
+                        )
                     else:
                         _cached_ut_unit[units] = ut_unit
                 # --- End: if
 
-#                if ut_unit is None:
-#                    ut_unit = _ut_parse(
-#                        _ut_system, _c_char_p(units.encode('utf-8')),
-#                        _UT_ASCII
-#                    )
-#                    if not ut_unit:
-#                        raise ValueError(
-#                            "Can't set unsupported unit: %r" % units)
-#                    _cached_ut_unit[units] = ut_unit
+                #                if ut_unit is None:
+                #                    ut_unit = _ut_parse(
+                #                        _ut_system, _c_char_p(units.encode('utf-8')),
+                #                        _UT_ASCII
+                #                    )
+                #                    if not ut_unit:
+                #                        raise ValueError(
+                #                            "Can't set unsupported unit: %r" % units)
+                #                    _cached_ut_unit[units] = ut_unit
 
                 self._isreftime = False
                 self._calendar = None
@@ -856,7 +882,8 @@ class Units():
                 self._utime = Utime(_canonical_calendar[calendar.lower()])
             except Exception as error:
                 self._new_reason_notvalid(
-                    'Invalid calendar={!r}'.format(calendar))
+                    "Invalid calendar={!r}".format(calendar)
+                )
                 self._isvalid = True
 
             return
@@ -891,153 +918,149 @@ class Units():
         self._units_since_reftime = None
 
     def __getstate__(self):
-        '''Called when pickling.
+        """Called when pickling.
 
-    :Returns:
+        :Returns:
 
-        `dict`
-            A dictionary of the instance's attributes
+            `dict`
+                A dictionary of the instance's attributes
 
-    **Examples:**
+        **Examples:**
 
-    >>> u = Units('days since 3-4-5', calendar='gregorian')
-    >>> u.__getstate__()
-    {'calendar': 'gregorian',
-     'units': 'days since 3-4-5'}
+        >>> u = Units('days since 3-4-5', calendar='gregorian')
+        >>> u.__getstate__()
+        {'calendar': 'gregorian',
+         'units': 'days since 3-4-5'}
 
-        '''
-        return dict([(attr, getattr(self, attr))
-                     for attr in ('_units', '_calendar')
-                     if hasattr(self, attr)])
+        """
+        return dict(
+            [
+                (attr, getattr(self, attr))
+                for attr in ("_units", "_calendar")
+                if hasattr(self, attr)
+            ]
+        )
 
     def __setstate__(self, odict):
-        '''Called when unpickling.
+        """Called when unpickling.
 
-    :Parameters:
+        :Parameters:
 
-        odict: `dict`
-            The output from the instance's `__getstate__` method.
+            odict: `dict`
+                The output from the instance's `__getstate__` method.
 
-    :Returns:
+        :Returns:
 
-        `None`
+            `None`
 
-        '''
+        """
         units = None
-        if '_units' in odict:
-            units = odict['_units']
+        if "_units" in odict:
+            units = odict["_units"]
 
         calendar = None
-        if '_calendar' in odict:
-            calendar = odict['_calendar']
+        if "_calendar" in odict:
+            calendar = odict["_calendar"]
 
         self.__init__(units=units, calendar=calendar)
 
     def __hash__(self):
-        '''x.__hash__() <==> hash(x)
-
-        '''
+        """x.__hash__() <==> hash(x)"""
         if not self._isreftime:
-            return hash(('Units', self._ut_unit))
+            return hash(("Units", self._ut_unit))
 
         return hash(
-            ('Units', self._ut_unit, self._utime.origin,
-             self._utime.calendar)
+            ("Units", self._ut_unit, self._utime.origin, self._utime.calendar)
         )
 
     def __repr__(self):
-        '''x.__repr__() <==> repr(x)
-
-        '''
-        return '<{0}: {1}>'.format(self.__class__.__name__, self)
+        """x.__repr__() <==> repr(x)"""
+        return "<{0}: {1}>".format(self.__class__.__name__, self)
 
     def __str__(self):
-        '''x.__str__() <==> str(x)
-
-        '''
+        """x.__str__() <==> str(x)"""
         string = []
         if self._units is not None:
-            if self._units == '':
-                string.append("\'\'")
+            if self._units == "":
+                string.append("''")
             else:
                 string.append(str(self._units))
         # --- End: if
 
         if self._calendar is not None:
-            string.append('{0}'.format(self._calendar))
+            string.append("{0}".format(self._calendar))
 
-        return ' '.join(string)
+        return " ".join(string)
 
     def __deepcopy__(self, memo):
-        '''Used if copy.deepcopy is called on the variable.
-
-        '''
+        """Used if copy.deepcopy is called on the variable."""
         return self
 
     def __bool__(self):
-        '''Truth value testing and the built-in operation ``bool``
+        """Truth value testing and the built-in operation ``bool``
 
-    x.__bool__() <==> x!=0
+        x.__bool__() <==> x!=0
 
-        '''
+        """
         return self._ut_unit is not None
 
     def __eq__(self, other):
-        '''The rich comparison operator ``==``
+        """The rich comparison operator ``==``
 
-    x.__eq__(y) <==> x==y
+        x.__eq__(y) <==> x==y
 
-        '''
+        """
         return self.equals(other)
 
     def __ne__(self, other):
-        '''The rich comparison operator ``!=``
+        """The rich comparison operator ``!=``
 
-    x.__ne__(y) <==> x!=y
+        x.__ne__(y) <==> x!=y
 
-        '''
+        """
         return not self.equals(other)
 
     def __gt__(self, other):
-        '''The rich comparison operator ``>``
+        """The rich comparison operator ``>``
 
-    x.__gt__(y) <==> x>y
+        x.__gt__(y) <==> x>y
 
-        '''
-        return self._comparison(other, '__gt__')
+        """
+        return self._comparison(other, "__gt__")
 
     def __ge__(self, other):
-        '''The rich comparison operator ````
+        """The rich comparison operator ````
 
-    x.__ge__(y) <==> x>y
+        x.__ge__(y) <==> x>y
 
-        '''
-        return self._comparison(other, '__ge__')
+        """
+        return self._comparison(other, "__ge__")
 
     def __lt__(self, other):
-        '''The rich comparison operator ````
+        """The rich comparison operator ````
 
-    x.__lt__(y) <==> x<y
+        x.__lt__(y) <==> x<y
 
-        '''
-        return self._comparison(other, '__lt__')
+        """
+        return self._comparison(other, "__lt__")
 
     def __le__(self, other):
-        '''The rich comparison operator ````
+        """The rich comparison operator ````
 
-    x.__le__(y) <==> x<=y
+        x.__le__(y) <==> x<=y
 
-        '''
-        return self._comparison(other, '__le__')
+        """
+        return self._comparison(other, "__le__")
 
     def __sub__(self, other):
-        '''The binary arithmetic operation ``-``
+        """The binary arithmetic operation ``-``
 
-    x.__sub__(y) <==> x-y
+        x.__sub__(y) <==> x-y
 
-        '''
-        if (self._isreftime or
-                (isinstance(other, self.__class__) and other._isreftime)):
+        """
+        if self._isreftime or (
+            isinstance(other, self.__class__) and other._isreftime
+        ):
             raise ValueError("Can't do {!r} - {!r}".format(self, other))
 
         try:
@@ -1047,13 +1070,14 @@ class Units():
             raise ValueError("Can't do {!r} - {!r}".format(self, other))
 
     def __add__(self, other):
-        '''The binary arithmetic operation ``+``
+        """The binary arithmetic operation ``+``
 
-    x.__add__(y) <==> x+y
+        x.__add__(y) <==> x+y
 
-        '''
-        if (self._isreftime or
-                (isinstance(other, self.__class__) and other._isreftime)):
+        """
+        if self._isreftime or (
+            isinstance(other, self.__class__) and other._isreftime
+        ):
             raise ValueError("Can't do {!r} + {!r}".format(self, other))
 
         try:
@@ -1063,11 +1087,11 @@ class Units():
             raise ValueError("Can't do {!r} + {!r}".format(self, other))
 
     def __mul__(self, other):
-        '''The binary arithmetic operation ``*``
+        """The binary arithmetic operation ``*``
 
-    x.__mul__(y) <==> x*y
+        x.__mul__(y) <==> x*y
 
-        '''
+        """
         if isinstance(other, self.__class__):
             if self._isreftime or other._isreftime:
                 raise ValueError("Can't do {!r} * {!r}".format(self, other))
@@ -1089,9 +1113,7 @@ class Units():
         return type(self)(_ut_unit=ut_unit)
 
     def __div__(self, other):
-        '''x.__div__(y) <==> x/y
-
-        '''
+        """x.__div__(y) <==> x/y"""
         if isinstance(other, self.__class__):
             if self._isreftime or other._isreftime:
                 raise ValueError("Can't do {!r} / {!r}".format(self, other))
@@ -1105,7 +1127,7 @@ class Units():
                 raise ValueError("Can't do {!r} / {!r}".format(self, other))
 
             try:
-                ut_unit = _ut_scale(_c_double(1.0/other), self._ut_unit)
+                ut_unit = _ut_scale(_c_double(1.0 / other), self._ut_unit)
             except:
                 raise ValueError("Can't do {!r} / {!r}".format(self, other))
         # --- End: if
@@ -1113,11 +1135,11 @@ class Units():
         return type(self)(_ut_unit=ut_unit)
 
     def __pow__(self, other, modulo=None):
-        '''The binary arithmetic operations ``**`` and ``pow``
+        """The binary arithmetic operations ``**`` and ``pow``
 
-    x.__pow__(y) <==> x**y
+        x.__pow__(y) <==> x**y
 
-        '''
+        """
         # ------------------------------------------------------------
         # y must be either an integer or the reciprocal of a positive
         # integer.
@@ -1126,7 +1148,9 @@ class Units():
         if modulo is not None:
             raise NotImplementedError(
                 "3-argument power not supported for {!r}".format(
-                    self.__class__.__name__))
+                    self.__class__.__name__
+                )
+            )
 
         if self and not self._isreftime:
             ut_unit = self._ut_unit
@@ -1140,7 +1164,7 @@ class Units():
                 # integer then take the (1/other)-th root. E.g. if
                 # other is 0.125 then we take the 8-th root.
                 try:
-                    recip_other = 1/other
+                    recip_other = 1 / other
                     root = int(recip_other)
                     if recip_other == root:
                         ut_unit = _ut_root(ut_unit, _c_int(root))
@@ -1166,172 +1190,148 @@ class Units():
         raise ValueError("Can't do {!r} ** {!r}".format(self, other))
 
     def __isub__(self, other):
-        '''x.__isub__(y) <==> x-=y
-
-        '''
+        """x.__isub__(y) <==> x-=y"""
         return self - other
 
     def __iadd__(self, other):
-        '''x.__iadd__(y) <==> x+=y
-
-        '''
+        """x.__iadd__(y) <==> x+=y"""
         return self + other
 
     def __imul__(self, other):
-        '''The augmented arithmetic assignment ``*=``
+        """The augmented arithmetic assignment ``*=``
 
-    x.__imul__(y) <==> x*=y
+        x.__imul__(y) <==> x*=y
 
-        '''
+        """
         return self * other
 
     def __idiv__(self, other):
-        '''The augmented arithmetic assignment ``/=``
+        """The augmented arithmetic assignment ``/=``
 
-    x.__idiv__(y) <==> x/=y
+        x.__idiv__(y) <==> x/=y
 
-        '''
+        """
         return self / other
 
     def __ipow__(self, other):
-        '''The augmented arithmetic assignment ``**=``
+        """The augmented arithmetic assignment ``**=``
 
-    x.__ipow__(y) <==> x**=y
+        x.__ipow__(y) <==> x**=y
 
-        '''
+        """
         return self ** other
 
     def __rsub__(self, other):
-        '''The binary arithmetic operation ``-`` with reflected operands
+        """The binary arithmetic operation ``-`` with reflected operands
 
-    x.__rsub__(y) <==> y-x
+        x.__rsub__(y) <==> y-x
 
-        '''
+        """
         try:
             return -self + other
         except:
             raise ValueError("Can't do {!r} - {!r}".format(other, self))
 
     def __radd__(self, other):
-        '''The binary arithmetic operation ``+`` with reflected operands
+        """The binary arithmetic operation ``+`` with reflected operands
 
-    x.__radd__(y) <==> y+x
+        x.__radd__(y) <==> y+x
 
-        '''
+        """
         return self + other
 
     def __rmul__(self, other):
-        '''The binary arithmetic operation ``*`` with reflected operands
+        """The binary arithmetic operation ``*`` with reflected operands
 
-    x.__rmul__(y) <==> y*x
+        x.__rmul__(y) <==> y*x
 
-        '''
+        """
         return self * other
 
     def __rdiv__(self, other):
-        '''x.__rdiv__(y) <==> y/x
-
-        '''
+        """x.__rdiv__(y) <==> y/x"""
         try:
             return (self ** -1) * other
         except:
             raise ValueError("Can't do {!r} / {!r}".format(other, self))
 
     def __floordiv__(self, other):
-        '''x.__floordiv__(y) <==> x//y <==> x/y
-
-        '''
+        """x.__floordiv__(y) <==> x//y <==> x/y"""
         return self / other
 
     def __ifloordiv__(self, other):
-        '''x.__ifloordiv__(y) <==> x//=y <==> x/=y
-
-        '''
+        """x.__ifloordiv__(y) <==> x//=y <==> x/=y"""
         return self / other
 
     def __rfloordiv__(self, other):
-        '''x.__rfloordiv__(y) <==> y//x <==> y/x
-
-        '''
+        """x.__rfloordiv__(y) <==> y//x <==> y/x"""
         try:
             return (self ** -1) * other
         except:
             raise ValueError("Can't do {!r} // {!r}".format(other, self))
 
     def __truediv__(self, other):
-        '''x.__truediv__(y) <==> x/y
-
-        '''
+        """x.__truediv__(y) <==> x/y"""
         return self.__div__(other)
 
     def __itruediv__(self, other):
-        '''x.__itruediv__(y) <==> x/=y
-
-        '''
+        """x.__itruediv__(y) <==> x/=y"""
         return self.__idiv__(other)
 
     def __rtruediv__(self, other):
-        '''x.__rtruediv__(y) <==> y/x
-
-        '''
+        """x.__rtruediv__(y) <==> y/x"""
         return self.__rdiv__(other)
 
     def __mod__(self, other):
-        '''TODO
-
-        '''
+        """TODO"""
         raise ValueError("Can't do {!r} % {!r}".format(other, self))
 
     def __neg__(self):
-        '''The unary arithmetic operation ``-``
+        """The unary arithmetic operation ``-``
 
-    x.__neg__() <==> -x
+        x.__neg__() <==> -x
 
-        '''
+        """
         return self * -1
 
     def __pos__(self):
-        '''The unary arithmetic operation ``+``
+        """The unary arithmetic operation ``+``
 
-    x.__pos__() <==> +x
+        x.__pos__() <==> +x
 
-        '''
+        """
         return self
 
     # ----------------------------------------------------------------
     # Private methods
     # ----------------------------------------------------------------
     def _comparison(self, other, method):
-        '''
-        '''
+        """"""
         try:
             cv_converter = _ut_get_converter(self._ut_unit, other._ut_unit)
         except:
             raise ValueError(
-                "Units are not compatible: {!r}, {!r}".format(self, other))
+                "Units are not compatible: {!r}, {!r}".format(self, other)
+            )
 
         if not cv_converter:
             _cv_free(cv_converter)
             raise ValueError(
-                "Units are not compatible: {!r}, {!r}".format(self, other))
+                "Units are not compatible: {!r}, {!r}".format(self, other)
+            )
 
         y = _c_double(1.0)
         pointer = ctypes.pointer(y)
-        _cv_convert_doubles(cv_converter,
-                            pointer,
-                            _c_size_t(1),
-                            pointer)
+        _cv_convert_doubles(cv_converter, pointer, _c_size_t(1), pointer)
         _cv_free(cv_converter)
 
         return getattr(operator, method)(y.value, 1)
 
     def _new_reason_notvalid(self, reason):
-        '''TODO
-
-        '''
+        """TODO"""
         _reason_notvalid = self._reason_notvalid
         if _reason_notvalid:
-            self._reason_notvalid = _reason_notvalid+'; '+reason
+            self._reason_notvalid = _reason_notvalid + "; " + reason
         else:
             self._reason_notvalid = reason
 
@@ -1340,156 +1340,157 @@ class Units():
     # ----------------------------------------------------------------
     @property
     def has_offset(self):
-        '''True if the units contain an offset.
+        """True if the units contain an offset.
 
-    Note that if a multiplicative component of the units had an offset
-    during instantiation, then the offset is ignored in the resulting
-    `Units` object. See below for examples.
+        Note that if a multiplicative component of the units had an offset
+        during instantiation, then the offset is ignored in the resulting
+        `Units` object. See below for examples.
 
-    **Examples**
+        **Examples**
 
-    >>> Units('K').has_offset
-    False
-    >>> Units('K @ 0').has_offset
-    False
-    >>> Units('K @ 273.15').has_offset
-    True
-    >>> Units('degC').has_offset
-    True
-    >>> Units('degF').has_offset
-    True
+        >>> Units('K').has_offset
+        False
+        >>> Units('K @ 0').has_offset
+        False
+        >>> Units('K @ 273.15').has_offset
+        True
+        >>> Units('degC').has_offset
+        True
+        >>> Units('degF').has_offset
+        True
 
-    >>> Units('Watt').has_offset
-    False
-    >>> Units('m2.kg.s-3').has_offset
-    False
+        >>> Units('Watt').has_offset
+        False
+        >>> Units('m2.kg.s-3').has_offset
+        False
 
-    >>> Units('km').has_offset
-    False
-    >>> Units('1000 m').has_offset
-    False
+        >>> Units('km').has_offset
+        False
+        >>> Units('1000 m').has_offset
+        False
 
-    >>> Units('m2.kg.s-3 @ 3.14').has_offset
-    True
-    >>> Units('(K @ 273.15) m s-1').has_offset
-    False
-    >>> Units('degC m s-1').has_offset
-    False
-    >>> Units('degC m s-1') == Units('K m s-1')
-    True
+        >>> Units('m2.kg.s-3 @ 3.14').has_offset
+        True
+        >>> Units('(K @ 273.15) m s-1').has_offset
+        False
+        >>> Units('degC m s-1').has_offset
+        False
+        >>> Units('degC m s-1') == Units('K m s-1')
+        True
 
-        '''
-        return '@' in self.formatted()
+        """
+        return "@" in self.formatted()
 
     @property
     def isreftime(self):
-        '''True if the units are reference time units, False otherwise.
+        """True if the units are reference time units, False otherwise.
 
-    Note that time units (such as ``'days'``) are not reference time
-    units.
+        Note that time units (such as ``'days'``) are not reference time
+        units.
 
-    .. seealso:: `isdimensionless`, `islongitude`, `islatitude`,
-                 `ispressure`, `istime`
+        .. seealso:: `isdimensionless`, `islongitude`, `islatitude`,
+                     `ispressure`, `istime`
 
-    **Examples:**
+        **Examples:**
 
-    >>> Units('days since 2000-12-1 03:00').isreftime
-    True
-    >>> Units('hours since 2100-1-1', calendar='noleap').isreftime
-    True
-    >>> Units(calendar='360_day').isreftime
-    True
-    >>> Units('days').isreftime
-    False
-    >>> Units('kg').isreftime
-    False
-    >>> Units().isreftime
-    False
+        >>> Units('days since 2000-12-1 03:00').isreftime
+        True
+        >>> Units('hours since 2100-1-1', calendar='noleap').isreftime
+        True
+        >>> Units(calendar='360_day').isreftime
+        True
+        >>> Units('days').isreftime
+        False
+        >>> Units('kg').isreftime
+        False
+        >>> Units().isreftime
+        False
 
-        '''
+        """
         return self._isreftime
 
     @property
     def iscalendartime(self):
-        '''True if the units are calendar time units, False otherwise.
+        """True if the units are calendar time units, False otherwise.
 
-    Note that regular time units (such as ``'days'``) are not calendar
-    time units.
+        Note that regular time units (such as ``'days'``) are not calendar
+        time units.
 
-    .. seealso:: `isdimensionless`, `islongitude`, `islatitude`,
-                 `ispressure`, `isreftime`, `istime`
+        .. seealso:: `isdimensionless`, `islongitude`, `islatitude`,
+                     `ispressure`, `isreftime`, `istime`
 
-    **Examples:**
+        **Examples:**
 
-    >>> Units('calendar_months').iscalendartime
-    True
-    >>> Units('calendar_years').iscalendartime
-    True
-    >>> Units('days').iscalendartime
-    False
-    >>> Units('km s-1').iscalendartime
-    False
-    >>> Units('kg').isreftime
-    False
-    >>> Units('').isreftime
-    False
-    >>> Units().isreftime
-    False
+        >>> Units('calendar_months').iscalendartime
+        True
+        >>> Units('calendar_years').iscalendartime
+        True
+        >>> Units('days').iscalendartime
+        False
+        >>> Units('km s-1').iscalendartime
+        False
+        >>> Units('kg').isreftime
+        False
+        >>> Units('').isreftime
+        False
+        >>> Units().isreftime
+        False
 
-        '''
+        """
         return bool(_ut_are_convertible(self._ut_unit, _calendartime_ut_unit))
 
     @property
     def isdimensionless(self):
-        '''True if the units are dimensionless, false otherwise.
+        """True if the units are dimensionless, false otherwise.
 
-    .. seealso:: `islongitude`, `islatitude`, `ispressure`, `isreftime`,
-                 `istime`
+        .. seealso:: `islongitude`, `islatitude`, `ispressure`, `isreftime`,
+                     `istime`
 
-    **Examples:**
+        **Examples:**
 
-    >>> Units('').isdimensionless
-    True
-    >>> Units('1').isdimensionless
-    True
-    >>> Units('100').isdimensionless
-    True
-    >>> Units('m/m').isdimensionless
-    True
-    >>> Units('m km-1').isdimensionless
-    True
-    >>> Units().isdimensionless
-    False
-    >>> Units('m').isdimensionless
-    False
-    >>> Units('m/s').isdimensionless
-    False
-    >>> Units('days since 2000-1-1', calendar='noleap').isdimensionless
-    False
+        >>> Units('').isdimensionless
+        True
+        >>> Units('1').isdimensionless
+        True
+        >>> Units('100').isdimensionless
+        True
+        >>> Units('m/m').isdimensionless
+        True
+        >>> Units('m km-1').isdimensionless
+        True
+        >>> Units().isdimensionless
+        False
+        >>> Units('m').isdimensionless
+        False
+        >>> Units('m/s').isdimensionless
+        False
+        >>> Units('days since 2000-1-1', calendar='noleap').isdimensionless
+        False
 
-        '''
+        """
         return bool(
-            _ut_are_convertible(self._ut_unit, _dimensionless_unit_one))
+            _ut_are_convertible(self._ut_unit, _dimensionless_unit_one)
+        )
 
     @property
     def ispressure(self):
-        '''True if the units are pressure units, false otherwise.
+        """True if the units are pressure units, false otherwise.
 
-    .. seealso:: `isdimensionless`, `islongitude`, `islatitude`,
-                 `isreftime`, `istime`
+        .. seealso:: `isdimensionless`, `islongitude`, `islatitude`,
+                     `isreftime`, `istime`
 
-    **Examples:**
+        **Examples:**
 
-    >>> Units('bar').ispressure
-    True
-    >>> Units('hPa').ispressure
-    True
-    >>> Units('meter^-1-kilogram-second^-2').ispressure
-    True
-    >>> Units('hours since 2100-1-1', calendar='noleap').ispressure
-    False
+        >>> Units('bar').ispressure
+        True
+        >>> Units('hPa').ispressure
+        True
+        >>> Units('meter^-1-kilogram-second^-2').ispressure
+        True
+        >>> Units('hours since 2100-1-1', calendar='noleap').ispressure
+        False
 
-        '''
+        """
         ut_unit = self._ut_unit
         if ut_unit is None:
             return False
@@ -1498,95 +1499,107 @@ class Units():
 
     @property
     def islatitude(self):
-        '''True if and only if the units are latitude units.
+        """True if and only if the units are latitude units.
 
-    This is the case if and only if the `units` attribute is one of
-    ``'degrees_north'``, ``'degree_north'``, ``'degree_N'``,
-    ``'degrees_N'``, ``'degreeN'``, and ``'degreesN'``.
+        This is the case if and only if the `units` attribute is one of
+        ``'degrees_north'``, ``'degree_north'``, ``'degree_N'``,
+        ``'degrees_N'``, ``'degreeN'``, and ``'degreesN'``.
 
-    Note that units of ``'degrees'`` are not latitude units.
+        Note that units of ``'degrees'`` are not latitude units.
 
-    .. seealso:: `isdimensionless`, `islongitude`, `ispressure`,
-                 `isreftime`, `istime`
+        .. seealso:: `isdimensionless`, `islongitude`, `ispressure`,
+                     `isreftime`, `istime`
 
-    **Examples:**
+        **Examples:**
 
-    >>> Units('degrees_north').islatitude
-    True
-    >>> Units('degrees').islatitude
-    False
-    >>> Units('degrees_east').islatitude
-    False
-    >>> Units('kg').islatitude
-    False
-    >>> Units().islatitude
-    False
+        >>> Units('degrees_north').islatitude
+        True
+        >>> Units('degrees').islatitude
+        False
+        >>> Units('degrees_east').islatitude
+        False
+        >>> Units('kg').islatitude
+        False
+        >>> Units().islatitude
+        False
 
-        '''
-        return self._units in ('degrees_north', 'degree_north', 'degree_N',
-                               'degrees_N', 'degreeN', 'degreesN')
+        """
+        return self._units in (
+            "degrees_north",
+            "degree_north",
+            "degree_N",
+            "degrees_N",
+            "degreeN",
+            "degreesN",
+        )
 
     @property
     def islongitude(self):
-        '''True if and only if the units are longitude units.
+        """True if and only if the units are longitude units.
 
-    This is the case if and only if the `units` attribute is one of
-    ``'degrees_east'``, ``'degree_east'``, ``'degree_E'``,
-    ``'degrees_E'``, ``'degreeE'``, and ``'degreesE'``.
+        This is the case if and only if the `units` attribute is one of
+        ``'degrees_east'``, ``'degree_east'``, ``'degree_E'``,
+        ``'degrees_E'``, ``'degreeE'``, and ``'degreesE'``.
 
-    Note that units of ``'degrees'`` are not longitude units.
+        Note that units of ``'degrees'`` are not longitude units.
 
-    .. seealso:: `isdimensionless`, `islatitude`, `ispressure`,
-                 `isreftime`, `istime`
+        .. seealso:: `isdimensionless`, `islatitude`, `ispressure`,
+                     `isreftime`, `istime`
 
-    **Examples:**
+        **Examples:**
 
-    >>> Units('degrees_east').islongitude
-    True
-    >>> Units('degrees').islongitude
-    False
-    >>> Units('degrees_north').islongitude
-    False
-    >>> Units('kg').islongitude
-    False
-    >>> Units().islongitude
-    False
+        >>> Units('degrees_east').islongitude
+        True
+        >>> Units('degrees').islongitude
+        False
+        >>> Units('degrees_north').islongitude
+        False
+        >>> Units('kg').islongitude
+        False
+        >>> Units().islongitude
+        False
 
-        '''
-        return self._units in ('degrees_east', 'degree_east', 'degree_E',
-                               'degrees_E', 'degreeE', 'degreesE')
+        """
+        return self._units in (
+            "degrees_east",
+            "degree_east",
+            "degree_E",
+            "degrees_E",
+            "degreeE",
+            "degreesE",
+        )
 
     @property
     def istime(self):
-        '''True if the units are time units, False otherwise.
+        """True if the units are time units, False otherwise.
 
-    Note that reference time units (such as ``'days since
-    2000-12-1'``) are not time units, nor are calendar years and
-    calendar months.
+        Note that reference time units (such as ``'days since
+        2000-12-1'``) are not time units, nor are calendar years and
+        calendar months.
 
-    .. seealso:: `iscalendartime`, `isdimensionless`, `islongitude`,
-                 `islatitude`, `ispressure`, `isreftime`
+        .. seealso:: `iscalendartime`, `isdimensionless`, `islongitude`,
+                     `islatitude`, `ispressure`, `isreftime`
 
-    **Examples:**
+        **Examples:**
 
-    >>> Units('days').istime
-    True
-    >>> Units('seconds').istime
-    True
-    >>> Units('kg').istime
-    False
-    >>> Units().istime
-    False
-    >>> Units('hours since 2100-1-1', calendar='noleap').istime
-    False
-    >>> Units(calendar='360_day').istime
-    False
-    >>> Units('calendar_years').istime
-    False
-    >>> Units('calendar_months').istime
-    False
+        >>> Units('days').istime
+        True
+        >>> Units('seconds').istime
+        True
+        >>> Units('kg').istime
+        False
+        >>> Units().istime
+        False
+        >>> Units('hours since 2100-1-1', calendar='noleap').istime
+        False
+        >>> Units(calendar='360_day').istime
+        False
+        >>> Units('calendar_years').istime
+        False
+        >>> Units('calendar_months').istime
+        False
 
-        '''
+        """
         if self._isreftime:
             return False
 
@@ -1598,80 +1611,80 @@ class Units():
 
     @property
     def isvalid(self):
-        '''Whether the units are valid.
+        """Whether the units are valid.
 
-    .. seealso:: `reason_notvalid`
+        .. seealso:: `reason_notvalid`
 
-    **Examples:**
+        **Examples:**
 
-    >>> u = Units('km')
-    >>>  u.isvalid
-    True
-    >>> u.reason_notvalid
-    ''
+        >>> u = Units('km')
+        >>>  u.isvalid
+        True
+        >>> u.reason_notvalid
+        ''
 
-    >>> u = Units('Bad Units')
-    >>> u.isvalid
-    False
-    >>> u.reason_notvalid
-    "Invalid units: 'Bad Units'; Not recognised by UDUNITS"
-    >>> u = Units(days since 2000-1-1', calendar='Bad Calendar')
-    >>>  u.isvalid
-    False
-    >>> u.reason_notvalid
-    "Invalid calendar='Bad Calendar'; calendar must be one of ['standard', 'gregorian', 'proleptic_gregorian', 'noleap', 'julian', 'all_leap', '365_day', '366_day', '360_day'], got 'bad calendar'"
+        >>> u = Units('Bad Units')
+        >>> u.isvalid
+        False
+        >>> u.reason_notvalid
+        "Invalid units: 'Bad Units'; Not recognised by UDUNITS"
+        >>> u = Units(days since 2000-1-1', calendar='Bad Calendar')
+        >>>  u.isvalid
+        False
+        >>> u.reason_notvalid
+        "Invalid calendar='Bad Calendar'; calendar must be one of ['standard', 'gregorian', 'proleptic_gregorian', 'noleap', 'julian', 'all_leap', '365_day', '366_day', '360_day'], got 'bad calendar'"
 
-        '''
-        return getattr(self, '_isvalid', False)
+        """
+        return getattr(self, "_isvalid", False)
 
     @property
     def reason_notvalid(self):
-        '''The reason for invalid units.
+        """The reason for invalid units.
 
-    If the units are valid then the reason is an empty string.
+        If the units are valid then the reason is an empty string.
 
-    .. seealso:: `isvalid`
+        .. seealso:: `isvalid`
 
-    **Examples:**
+        **Examples:**
 
-    >>> u = Units('km')
-    >>> u.isvalid
-    True
-    >>> u.reason_notvalid
-    ''
+        >>> u = Units('km')
+        >>> u.isvalid
+        True
+        >>> u.reason_notvalid
+        ''
 
-    >>> u = Units('Bad Units')
-    >>> u.isvalid
-    False
-    >>> u.reason_notvalid
-    "Invalid units: 'Bad Units'; Not recognised by UDUNITS"
+        >>> u = Units('Bad Units')
+        >>> u.isvalid
+        False
+        >>> u.reason_notvalid
+        "Invalid units: 'Bad Units'; Not recognised by UDUNITS"
 
-    >>> u = Units(days since 2000-1-1', calendar='Bad Calendar')
-    >>>  u.isvalid
-    False
-    >>> u.reason_notvalid
-    "Invalid calendar='Bad Calendar'; calendar must be one of ['standard', 'gregorian', 'proleptic_gregorian', 'noleap', 'julian', 'all_leap', '365_day', '366_day', '360_day'], got 'bad calendar'"
+        >>> u = Units(days since 2000-1-1', calendar='Bad Calendar')
+        >>>  u.isvalid
+        False
+        >>> u.reason_notvalid
+        "Invalid calendar='Bad Calendar'; calendar must be one of ['standard', 'gregorian', 'proleptic_gregorian', 'noleap', 'julian', 'all_leap', '365_day', '366_day', '360_day'], got 'bad calendar'"
 
-        '''
-        return getattr(self, '_reason_notvalid', '')
+        """
+        return getattr(self, "_reason_notvalid", "")
 
     @property
     def reftime(self):
-        '''The reference date-time of reference time units.
+        """The reference date-time of reference time units.
 
-    .. seealso:: `calendar`, `isreftime`, `units`
+        .. seealso:: `calendar`, `isreftime`, `units`
 
-    :Returns:
+        :Returns:
 
-        `cftime.datetime`
+            `cftime.datetime`
 
-    **Examples:**
+        **Examples:**
 
-    >>> u = Units('days since 2001-01-01', calendar='360_day')
-    >>> u.reftime
-    cftime.datetime(2001, 1, 1, 0, 0, 0, 0)
+        >>> u = Units('days since 2001-01-01', calendar='360_day')
+        >>> u.reftime
+        cftime.datetime(2001, 1, 1, 0, 0, 0, 0)
 
-        '''
+        """
         if self.isreftime:
             # utime = self._utime
             # if utime:
@@ -1687,62 +1700,59 @@ class Units():
 
             calendar = self._canonical_calendar
             return cftime.datetime(
-                *cftime._parse_date(self.units.split(' since ')[1])[:7],
+                *cftime._parse_date(self.units.split(" since ")[1])[:7],
                 calendar=calendar
             )
 
-        raise AttributeError(
-            "{!r} has no attribute 'reftime'".format(self))
+        raise AttributeError("{!r} has no attribute 'reftime'".format(self))
 
     @property
     def calendar(self):
-        '''The calendar for reference time units.
+        """The calendar for reference time units.
 
-    May be any string allowed by the calendar CF property.
+        May be any string allowed by the calendar CF property.
 
-    If it is unset then the default CF calendar is assumed when
-    required.
+        If it is unset then the default CF calendar is assumed when
+        required.
 
-    .. seealso:: `units`
+        .. seealso:: `units`
 
-    **Examples:**
+        **Examples:**
 
-    >>> Units(calendar='365_day').calendar
-    '365_day'
-    >>> Units('days since 2001-1-1', calendar='noleap').calendar
-    'noleap'
-    >>> Units('days since 2001-1-1').calendar
-    AttributeError: Units has no attribute 'calendar'
+        >>> Units(calendar='365_day').calendar
+        '365_day'
+        >>> Units('days since 2001-1-1', calendar='noleap').calendar
+        'noleap'
+        >>> Units('days since 2001-1-1').calendar
+        AttributeError: Units has no attribute 'calendar'
 
-        '''
+        """
         value = self._calendar
         if value is not None:
             return value
 
         raise AttributeError(
-            "{} has no attribute 'calendar'".format(
-                self.__class__.__name__
-            )
+            "{} has no attribute 'calendar'".format(self.__class__.__name__)
         )
 
     @property
     def units(self):
-        '''The units.
+        """The units.
 
-    May be any string allowed by the units CF property.
+        May be any string allowed by the units CF property.
 
-    .. seealso:: `calendar`
+        .. seealso:: `calendar`
 
-    **Examples:**
+        **Examples:**
 
-    >>> Units('kg').units
-    'kg'
-    >>> Units('seconds').units
-    'seconds'
-    >>> Units('days since 2000-1-1', calendar='366_day').units
-    'days since 2000-1-1'
+        >>> Units('kg').units
+        'kg'
+        >>> Units('seconds').units
+        'seconds'
+        >>> Units('days since 2000-1-1', calendar='366_day').units
+        'days since 2000-1-1'
 
-        '''
+        """
         value = self._units
         if value is not None:
             return value
@@ -1757,91 +1767,95 @@ class Units():
     # Methods
     # ----------------------------------------------------------------
     def equivalent(self, other, verbose=False):
-        '''Returns True if numeric values in one unit are convertible to
-    numeric values in the other unit.
+        """Returns True if numeric values in one unit are convertible to
+        numeric values in the other unit.
 
-    .. seealso:: `equals`
+        .. seealso:: `equals`
 
-    :Parameters:
+        :Parameters:
 
-        other: `Units`
-            The other units.
+            other: `Units`
+                The other units.
 
-    :Returns:
+        :Returns:
 
-        `bool`
-            True if the units are equivalent, False otherwise.
+            `bool`
+                True if the units are equivalent, False otherwise.
 
-    **Examples:**
+        **Examples:**
 
-    >>> u = Units('m')
-    >>> v = Units('km')
-    >>> w = Units('s')
+        >>> u = Units('m')
+        >>> v = Units('km')
+        >>> w = Units('s')
 
-    >>> u.equivalent(v)
-    True
-    >>> u.equivalent(w)
-    False
+        >>> u.equivalent(v)
+        True
+        >>> u.equivalent(w)
+        False
 
-    >>> u = Units('days since 2000-1-1')
-    >>> v = Units('days since 2000-1-1', calendar='366_day')
-    >>> w = Units('seconds since 1978-3-12', calendar='gregorian)
+        >>> u = Units('days since 2000-1-1')
+        >>> v = Units('days since 2000-1-1', calendar='366_day')
+        >>> w = Units('seconds since 1978-3-12', calendar='gregorian)
 
-    >>> u.equivalent(v)
-    False
-    >>> u.equivalent(w)
-    True
+        >>> u.equivalent(v)
+        False
+        >>> u.equivalent(w)
+        True
 
-    Invalid units are not equivalent:
+        Invalid units are not equivalent:
 
-    >>> Units('bad units').equivalent(Units('bad units'))
-    False
+        >>> Units('bad units').equivalent(Units('bad units'))
+        False
 
-        '''
-#        if not self.isvalid or not other.isvalid:
-#            return False
+        """
+        #        if not self.isvalid or not other.isvalid:
+        #            return False
 
         isreftime1 = self._isreftime
         isreftime2 = other._isreftime
 
-#        if isreftime1 and isreftime2:
-#            # Both units are reference-time units
-#            if self._canonical_calendar != other._canonical_calendar:
-#                if verbose:
-#                    print("{}: Incompatible calendars: {!r}, {!r}".format(
-#                        self.__class__.__name__,
-#                        self._calendar, other._calendar))  # pragma: no cover
-#                return False
-#
-#            reftime0 = getattr(self, 'reftime', None)
-#            reftime1 = getattr(other, 'reftime', None)
-#            if reftime0 != reftime1:
-#                if verbose:
-#                    print(
-#                        "{}: Different reference date-times: "
-#                        "{!r}, {!r}".format(
-#                            self.__class__.__name__,
-#                            reftime0, reftime1
-#                        )
-#                    )  # pragma: no cover
-#                return False
-#
-#        elif isreftime1 or isreftime2:
-#            if verbose:
-#                print("{}: Only one is reference time".format(
-#                    self.__class__.__name__))  # pragma: no cover
-#            return False
+        #        if isreftime1 and isreftime2:
+        #            # Both units are reference-time units
+        #            if self._canonical_calendar != other._canonical_calendar:
+        #                if verbose:
+        #                    print("{}: Incompatible calendars: {!r}, {!r}".format(
+        #                        self.__class__.__name__,
+        #                        self._calendar, other._calendar))  # pragma: no cover
+        #                return False
+        #
+        #            reftime0 = getattr(self, 'reftime', None)
+        #            reftime1 = getattr(other, 'reftime', None)
+        #            if reftime0 != reftime1:
+        #                if verbose:
+        #                    print(
+        #                        "{}: Different reference date-times: "
+        #                        "{!r}, {!r}".format(
+        #                            self.__class__.__name__,
+        #                            reftime0, reftime1
+        #                        )
+        #                    )  # pragma: no cover
+        #                return False
+        #
+        #        elif isreftime1 or isreftime2:
+        #            if verbose:
+        #                print("{}: Only one is reference time".format(
+        #                    self.__class__.__name__))  # pragma: no cover
+        #            return False
 
         if isreftime1 and isreftime2:
             # Both units are reference-time units
             units0 = self._units
             units1 = other._units
             if units0 and units1 or (not units0 and not units1):
-                out = (self._canonical_calendar == other._canonical_calendar)
+                out = self._canonical_calendar == other._canonical_calendar
                 if verbose and not out:
-                    print("{}: Incompatible calendars: {!r}, {!r}".format(
-                        self.__class__.__name__,
-                        self._calendar, other._calendar))  # pragma: no cover
+                    print(
+                        "{}: Incompatible calendars: {!r}, {!r}".format(
+                            self.__class__.__name__,
+                            self._calendar,
+                            other._calendar,
+                        )
+                    )  # pragma: no cover
 
                 return out
             else:
@@ -1849,35 +1863,38 @@ class Units():
 
         elif isreftime1 or isreftime2:
             if verbose:
-                print("{}: Only one is reference time".format(
-                    self.__class__.__name__))  # pragma: no cover
+                print(
+                    "{}: Only one is reference time".format(
+                        self.__class__.__name__
+                    )
+                )  # pragma: no cover
             return False
 
-#        if not self.isvalid:
-#            if verbose:
-#                print(
-#                    "{}: {!r} is not valid".format(
-#                        self.__class__.__name__, self)
-#                )  # pragma: no cover
-#            return False
-#
-#        if not other.isvalid:
-#            if verbose:
-#                print(
-#                    "{}: {!r} is not valid".format(
-#                        self.__class__.__name__, other)
-#                )  # pragma: no cover
-#            return False
+        #        if not self.isvalid:
+        #            if verbose:
+        #                print(
+        #                    "{}: {!r} is not valid".format(
+        #                        self.__class__.__name__, self)
+        #                )  # pragma: no cover
+        #            return False
+        #
+        #        if not other.isvalid:
+        #            if verbose:
+        #                print(
+        #                    "{}: {!r} is not valid".format(
+        #                        self.__class__.__name__, other)
+        #                )  # pragma: no cover
+        #            return False
 
-#         if isreftime1 and isreftime2:
-#            # Both units are reference-time units
-#            units0 = self._units
-#            units1 = other._units
-#            if units0 and units1 or (not units0 and not units1):
-#                return self._calendar == other._calendar
-#            else:
-#                return False
-#        # --- End: if
+        #         if isreftime1 and isreftime2:
+        #            # Both units are reference-time units
+        #            units0 = self._units
+        #            units1 = other._units
+        #            if units0 and units1 or (not units0 and not units1):
+        #                return self._calendar == other._calendar
+        #            else:
+        #                return False
+        #        # --- End: if
 
         # Still here?
         if self._units is None and other._units is None:
@@ -1887,87 +1904,87 @@ class Units():
 
         # Units('') and Units() are equivalent. v3.3.0 (updated test
         # criteria at v3.3.1)
-        if self._units in (None, '') and other._units in (None, ''):
+        if self._units in (None, "") and other._units in (None, ""):
             return True
 
         return bool(_ut_are_convertible(self._ut_unit, other._ut_unit))
 
     def formatted(self, names=None, definition=None):
-        '''Formats the string stored in the `units` attribute in a
-    standardized manner. The `units` attribute is modified in place
-    and its new value is returned.
+        """Formats the string stored in the `units` attribute in a
+        standardized manner. The `units` attribute is modified in place
+        and its new value is returned.
 
-    :Parameters:
+        :Parameters:
 
-        names: `bool`, optional
-            Use unit names instead of symbols.
+            names: `bool`, optional
+                Use unit names instead of symbols.
 
-        definition: `bool`, optional
-            The formatted string is given in terms of basic units
-            instead of stopping any expansion at the highest level
-            possible.
+            definition: `bool`, optional
+                The formatted string is given in terms of basic units
+                instead of stopping any expansion at the highest level
+                possible.
 
-    :Returns:
+        :Returns:
 
-        `str` or `None`
-            The formatted string. If the units have not yet been set,
-            then `None` is returned.
+            `str` or `None`
+                The formatted string. If the units have not yet been set,
+                then `None` is returned.
 
-    **Examples:**
+        **Examples:**
 
-    >>> u = Units('W')
-    >>> u.units
-    'W'
-    >>> u.formatted(names=True)
-    'watt'
-    >>> u.formatted(definition=True)
-    'm2.kg.s-3'
-    >>> u.formatted(names=True, definition=True)
-    'meter^2-kilogram-second^-3'
-    >>> u.formatted()
-    'W'
+        >>> u = Units('W')
+        >>> u.units
+        'W'
+        >>> u.formatted(names=True)
+        'watt'
+        >>> u.formatted(definition=True)
+        'm2.kg.s-3'
+        >>> u.formatted(names=True, definition=True)
+        'meter^2-kilogram-second^-3'
+        >>> u.formatted()
+        'W'
 
-    >>> u = Units('dram')
-    >>> u.formatted(names=True)
-    '0.001771845 kilogram'
+        >>> u = Units('dram')
+        >>> u.formatted(names=True)
+        '0.001771845 kilogram'
 
-    >>> u = Units('hours since 2100-1-1', calendar='noleap')
-    >>> u.formatted(names=True)
-    'hour since 2100-1-1 00:00:00'
-    >>> u.formatted()
-    'h since 2100-1-1 00:00:00'
+        >>> u = Units('hours since 2100-1-1', calendar='noleap')
+        >>> u.formatted(names=True)
+        'hour since 2100-1-1 00:00:00'
+        >>> u.formatted()
+        'h since 2100-1-1 00:00:00'
 
-    Formatting is also available during object initialization:
+        Formatting is also available during object initialization:
 
-    >>> u = Units('m/s', formatted=True)
-    >>> u.units
-    'm.s-1'
+        >>> u = Units('m/s', formatted=True)
+        >>> u.units
+        'm.s-1'
 
-    >>> u = Units('dram', names=True)
-    >>> u.units
-    '0.001771845 kilogram'
+        >>> u = Units('dram', names=True)
+        >>> u.units
+        '0.001771845 kilogram'
 
-    >>> u = Units('Watt')
-    >>> u.units
-    'Watt'
+        >>> u = Units('Watt')
+        >>> u.units
+        'Watt'
 
-    >>> u = Units('Watt', formatted=True)
-    >>> u.units
-    'W'
+        >>> u = Units('Watt', formatted=True)
+        >>> u.units
+        'W'
 
-    >>> u = Units('Watt', names=True)
-    >>> u.units
-    'watt'
+        >>> u = Units('Watt', names=True)
+        >>> u.units
+        'watt'
 
-    >>> u = Units('Watt', definition=True)
-    >>> u.units
-    'm2.kg.s-3'
+        >>> u = Units('Watt', definition=True)
+        >>> u.units
+        'm2.kg.s-3'
 
-    >>> u = Units('Watt', names=True, definition=True)
-    >>> u.units
-    'meter^2-kilogram-second^-3'
+        >>> u = Units('Watt', names=True, definition=True)
+        >>> u.units
+        'meter^2-kilogram-second^-3'
 
-        '''
+        """
         ut_unit = self._ut_unit
 
         if ut_unit is None:
@@ -1985,75 +2002,75 @@ class Units():
             raise ValueError("Can't format unit {!r}".format(self))
 
         if self.isreftime:
-            out = str(out, 'utf-8')  # needs converting from byte-string
-            out += ' since ' + self.reftime.strftime()
+            out = str(out, "utf-8")  # needs converting from byte-string
+            out += " since " + self.reftime.strftime()
             return out
 
-        return out.decode('utf-8')
+        return out.decode("utf-8")
 
     @classmethod
     def conform(cls, x, from_units, to_units, inplace=False):
-        '''Conform values in one unit to equivalent values in another,
-    compatible unit.
+        """Conform values in one unit to equivalent values in another,
+        compatible unit.
 
-    Returns the conformed values.
+        Returns the conformed values.
 
-    The values may either be a `numpy` array, a Python numeric type,
-    or a `list` or `tuple`. The returned value is of the same type,
-    except that input integers are converted to floats and Python
-    sequences are converted to `numpy` arrays (see the *inplace*
-    keyword).
+        The values may either be a `numpy` array, a Python numeric type,
+        or a `list` or `tuple`. The returned value is of the same type,
+        except that input integers are converted to floats and Python
+        sequences are converted to `numpy` arrays (see the *inplace*
+        keyword).
 
-    .. warning:: Do not change the calendar of reference time units in
-                 the current version. Whilst this is possible, it will
-                 almost certainly result in an incorrect
-                 interpretation of the data or an error.
+        .. warning:: Do not change the calendar of reference time units in
+                     the current version. Whilst this is possible, it will
+                     almost certainly result in an incorrect
+                     interpretation of the data or an error.
 
-    :Parameters:
+        :Parameters:
 
-        x: `numpy.ndarray` or Python numeric type or `list` or `tuple`
+            x: `numpy.ndarray` or Python numeric type or `list` or `tuple`
 
-        from_units: `Units`
-            The original units of *x*
+            from_units: `Units`
+                The original units of *x*
 
-        to_units: `Units`
-            The units to which *x* should be conformed to.
+            to_units: `Units`
+                The units to which *x* should be conformed to.
 
-        inplace: `bool`, optional
-            If True and *x* is a `numpy` array then change it in place,
-            creating no temporary copies, with one exception: If *x*
-            is of integer type and the conversion is not null, then it
-            will not be changed inplace and the returned conformed
-            array will be of float type.
+            inplace: `bool`, optional
+                If True and *x* is a `numpy` array then change it in place,
+                creating no temporary copies, with one exception: If *x*
+                is of integer type and the conversion is not null, then it
+                will not be changed inplace and the returned conformed
+                array will be of float type.
 
-            If *x* is a `list` or `tuple` then the *inplace* parameter
-            is ignored and a `numpy` array is returned.
+                If *x* is a `list` or `tuple` then the *inplace* parameter
+                is ignored and a `numpy` array is returned.
 
-    :Returns:
+        :Returns:
 
-        `numpy.ndarray` or Python numeric
-            The modified numeric values.
+            `numpy.ndarray` or Python numeric
+                The modified numeric values.
 
-    **Examples:**
+        **Examples:**
 
-    >>> Units.conform(2, Units('km'), Units('m'))
-    2000.0
+        >>> Units.conform(2, Units('km'), Units('m'))
+        2000.0
 
-    >>> import numpy
-    >>> a = numpy.arange(5.0)
-    >>> Units.conform(a, Units('minute'), Units('second'))
-    array([   0.,   60.,  120.,  180.,  240.])
-    >>> print(a)
-    [ 0.  1.  2.  3.  4.]
+        >>> import numpy
+        >>> a = numpy.arange(5.0)
+        >>> Units.conform(a, Units('minute'), Units('second'))
+        array([   0.,   60.,  120.,  180.,  240.])
+        >>> print(a)
+        [ 0.  1.  2.  3.  4.]
 
-    >>> Units.conform(a,
-                      Units('days since 2000-12-1'),
-                      Units('days since 2001-1-1'), inplace=True)
-    array([-31., -30., -29., -28., -27.])
-    >>> print(a)
-    [-31. -30. -29. -28. -27.]
+        >>> Units.conform(a,
+                          Units('days since 2000-12-1'),
+                          Units('days since 2001-1-1'), inplace=True)
+        array([-31., -30., -29., -28., -27.])
+        >>> print(a)
+        [-31. -30. -29. -28. -27.]
 
-        '''
+        """
         if from_units.equals(to_units):
             if not isinstance(x, (int, float)):
                 x = numpy_asanyarray(x)
@@ -2068,15 +2085,21 @@ class Units():
         # --- End: if
 
         if not from_units.equivalent(to_units):
-            raise ValueError("Units are not convertible: {!r}, {!r}".format(
-                from_units, to_units))
+            raise ValueError(
+                "Units are not convertible: {!r}, {!r}".format(
+                    from_units, to_units
+                )
+            )
 
         ut_unit1 = from_units._ut_unit
         ut_unit2 = to_units._ut_unit
 
         if ut_unit1 is None or ut_unit2 is None:
-            raise ValueError("Units are not convertible: {!r}, {!r}".format(
-                from_units, to_units))
+            raise ValueError(
+                "Units are not convertible: {!r}, {!r}".format(
+                    from_units, to_units
+                )
+            )
 
         convert = _ut_compare(ut_unit1, ut_unit2)
 
@@ -2085,20 +2108,21 @@ class Units():
             # Both units are time-reference units, so calculate the
             # non-zero offset in units of days.
             # --------------------------------------------------------
-            units0, reftime0 = from_units.units.split(' since ')
-            units1, reftime1 = to_units.units.split(' since ')
+            units0, reftime0 = from_units.units.split(" since ")
+            units1, reftime1 = to_units.units.split(" since ")
             if units0 in _months_or_years:
                 from_units = cls(
-                    'days since '+reftime0,
-                    calendar=getattr(from_units, 'calendar', None))
+                    "days since " + reftime0,
+                    calendar=getattr(from_units, "calendar", None),
+                )
                 x = numpy_asanyarray(x)
                 if inplace:
-                    if units0 in ('month', 'months'):
+                    if units0 in ("month", "months"):
                         x *= _month_length
                     else:
                         x *= _year_length
                 else:
-                    if units0 in ('month', 'months'):
+                    if units0 in ("month", "months"):
                         x = x * _month_length
                     else:
                         x = x * _year_length
@@ -2111,18 +2135,20 @@ class Units():
                 convert = _ut_compare(ut_unit1, ut_unit2)
 
             if units1 in _months_or_years:
-                to_units = cls('days since '+reftime1,
-                               calendar=getattr(to_units, 'calendar', None))
+                to_units = cls(
+                    "days since " + reftime1,
+                    calendar=getattr(to_units, "calendar", None),
+                )
 
             to_jd0 = cftime.JulianDayFromDate(
-                to_units._utime.origin,
-                calendar=to_units._utime.calendar)
+                to_units._utime.origin, calendar=to_units._utime.calendar
+            )
             from_jd0 = cftime.JulianDayFromDate(
-                from_units._utime.origin,
-                calendar=from_units._utime.calendar)
+                from_units._utime.origin, calendar=from_units._utime.calendar
+            )
 
             offset = to_jd0 - from_jd0
-#            offset = to_units._utime._jd0 - from_units._utime._jd0
+        #            offset = to_units._utime._jd0 - from_units._utime._jd0
         else:
             offset = 0
 
@@ -2130,8 +2156,8 @@ class Units():
         # If the two units are identical then no need to alter the
         # value, so return it unchanged.
         # ------------------------------------------------------------
-#        if not convert and not offset:
-#            return x
+        #        if not convert and not offset:
+        #            return x
 
         if convert:
             cv_converter = _ut_get_converter(ut_unit1, ut_unit2)
@@ -2139,7 +2165,9 @@ class Units():
                 _cv_free(cv_converter)
                 raise ValueError(
                     "Units are not convertible: {!r}, {!r}".format(
-                        from_units, to_units))
+                        from_units, to_units
+                    )
+                )
         # --- End: if
 
         # ------------------------------------------------------------
@@ -2164,28 +2192,28 @@ class Units():
 
         if x_is_numpy:
             if not x.flags.contiguous:
-                x = numpy_array(x, order='C')
-# ARRRGGHH dch TODO
+                x = numpy_array(x, order="C")
+            # ARRRGGHH dch TODO
 
             # --------------------------------------------------------
             # Convert an integer numpy array to a float numpy array
             # --------------------------------------------------------
             if inplace:
-                if x.dtype.kind == 'i':
-                    if x.dtype.char == 'i':
-                        y = x.view(dtype='float32')
+                if x.dtype.kind == "i":
+                    if x.dtype.char == "i":
+                        y = x.view(dtype="float32")
                         y[...] = x
-                        x.dtype = numpy_dtype('float32')
-                    elif x.dtype.char == 'l':
+                        x.dtype = numpy_dtype("float32")
+                    elif x.dtype.char == "l":
                         y = x.view(dtype=float)
                         y[...] = x
                         x.dtype = numpy_dtype(float)
             else:
                 # At numpy vn1.7 astype has many more keywords ...
-                if x.dtype.kind == 'i':
-                    if x.dtype.char == 'i':
-                        x = x.astype('float32')
-                    elif x.dtype.char == 'l':
+                if x.dtype.kind == "i":
+                    if x.dtype.char == "i":
+                        x = x.astype("float32")
+                    elif x.dtype.char == "l":
                         x = x.astype(float)
                 else:
                     x = x.copy()
@@ -2203,20 +2231,18 @@ class Units():
                 pointer = x.ctypes.data_as(_ctypes_POINTER[itemsize])
 
                 # Convert the array in place
-                _cv_convert_array[itemsize](cv_converter,
-                                            pointer,
-                                            _c_size_t(x.size),
-                                            pointer)
+                _cv_convert_array[itemsize](
+                    cv_converter, pointer, _c_size_t(x.size), pointer
+                )
             else:
                 # Create a pointer to the number cast to a ctypes
                 # double object.
                 y = _c_double(x)
                 pointer = ctypes.pointer(y)
                 # Convert the pointer
-                _cv_convert_doubles(cv_converter,
-                                    pointer,
-                                    _c_size_t(1),
-                                    pointer)
+                _cv_convert_doubles(
+                    cv_converter, pointer, _c_size_t(1), pointer
+                )
                 # Reset the number
                 x = y.value
 
@@ -2232,12 +2258,10 @@ class Units():
 
                 cv_converter = _ut_get_converter(_day_ut_unit, ut_unit2)
                 scale = numpy_array(1.0)
-                pointer = scale.ctypes.data_as(
-                    ctypes.POINTER(ctypes.c_double))
-                _cv_convert_doubles(cv_converter,
-                                    pointer,
-                                    _c_size_t(scale.size),
-                                    pointer)
+                pointer = scale.ctypes.data_as(ctypes.POINTER(ctypes.c_double))
+                _cv_convert_doubles(
+                    cv_converter, pointer, _c_size_t(scale.size), pointer
+                )
                 _cv_free(cv_converter)
 
                 offset *= scale.item()
@@ -2247,71 +2271,71 @@ class Units():
         return x
 
     def copy(self):
-        '''Return a deep copy.
+        """Return a deep copy.
 
-    Equivalent to ``copy.deepcopy(u)``.
+        Equivalent to ``copy.deepcopy(u)``.
 
-    :Returns:
+        :Returns:
 
-            The deep copy.
+                The deep copy.
 
-    **Examples:**
+        **Examples:**
 
-    >>> v = u.copy()
+        >>> v = u.copy()
 
-        '''
+        """
         return self
 
     def equals(self, other, rtol=None, atol=None, verbose=False):
-        '''Return True if and only if numeric values in one unit are
-    convertible to numeric values in the other unit and their
-    conversion is a scale factor of 1.
+        """Return True if and only if numeric values in one unit are
+        convertible to numeric values in the other unit and their
+        conversion is a scale factor of 1.
 
-    .. seealso:: `equivalent`
+        .. seealso:: `equivalent`
 
-    :Parameters:
+        :Parameters:
 
-        other: `Units`
-            The other units.
+            other: `Units`
+                The other units.
 
-    :Returns:
+        :Returns:
 
-        `bool`
-            `True` if the units are equal, `False` otherwise.
+            `bool`
+                `True` if the units are equal, `False` otherwise.
 
-    **Examples:**
+        **Examples:**
 
-    >>> u = Units('km')
-    >>> v = Units('1000m')
-    >>> w = Units('100000m')
-    >>> u.equals(v)
-    True
-    >>> u.equals(w)
-    False
+        >>> u = Units('km')
+        >>> v = Units('1000m')
+        >>> w = Units('100000m')
+        >>> u.equals(v)
+        True
+        >>> u.equals(w)
+        False
 
-    >>> u = Units('m s-1')
-    >>> m = Units('m')
-    >>> s = Units('s')
-    >>> u.equals(m)
-    False
-    >>> u.equals(m/s)
-    True
-    >>> (m/s).equals(u)
-    True
+        >>> u = Units('m s-1')
+        >>> m = Units('m')
+        >>> s = Units('s')
+        >>> u.equals(m)
+        False
+        >>> u.equals(m/s)
+        True
+        >>> (m/s).equals(u)
+        True
 
-    Undefined units are considered equal:
+        Undefined units are considered equal:
 
-    >>> u = Units()
-    >>> v = Units()
-    >>> u.equals(v)
-    True
+        >>> u = Units()
+        >>> v = Units()
+        >>> u.equals(v)
+        True
 
-    Invalid units are not equal:
+        Invalid units are not equal:
 
-    >>> Units('bad units').equals(Units('bad units'))
-    False
+        >>> Units('bad units').equals(Units('bad units'))
+        False
 
-        '''
+        """
         isreftime1 = self._isreftime
         isreftime2 = other._isreftime
 
@@ -2319,73 +2343,81 @@ class Units():
             # Both units are reference-time units
             if self._canonical_calendar != other._canonical_calendar:
                 if verbose:
-                    print("{}: Incompatible calendars: {!r}, {!r}".format(
-                        self.__class__.__name__,
-                        self._calendar, other._calendar))  # pragma: no cover
+                    print(
+                        "{}: Incompatible calendars: {!r}, {!r}".format(
+                            self.__class__.__name__,
+                            self._calendar,
+                            other._calendar,
+                        )
+                    )  # pragma: no cover
 
                 return False
 
-            reftime0 = getattr(self, 'reftime', None)
-            reftime1 = getattr(other, 'reftime', None)
+            reftime0 = getattr(self, "reftime", None)
+            reftime1 = getattr(other, "reftime", None)
             if reftime0 != reftime1:
                 if verbose:
-                    print("{}: Different reference date-times: "
-                          "{!r}, {!r}".format(
-                              self.__class__.__name__,
-                              reftime0, reftime1))  # pragma: no cover
+                    print(
+                        "{}: Different reference date-times: "
+                        "{!r}, {!r}".format(
+                            self.__class__.__name__, reftime0, reftime1
+                        )
+                    )  # pragma: no cover
 
                 return False
 
         elif isreftime1 or isreftime2:
             if verbose:
-                print("{}: Only one is reference time".format(
-                    self.__class__.__name__))  # pragma: no cover
+                print(
+                    "{}: Only one is reference time".format(
+                        self.__class__.__name__
+                    )
+                )  # pragma: no cover
 
             return False
 
+        #            utime0 = self._utime
+        #            utime1 = other._utime
+        #            if utime0 is not None and utime1 is not None:
+        #                return utime0.origin_equals(utime1)
+        #            elif utime0 is None and utime1 is None:
+        #                return self.reftime
+        #
+        #
+        #
+        #            units0 = self._units
+        #            units1 = other._units
+        #            if units0 and units1 or (not units0 and not units1):
+        #                out = (self._canonical_calendar == other._canonical_calendar)
+        #                if verbose and not out:
+        #                    print("{}: Incompatible calendars: {!r}, {!r}".format(
+        #                        self.__class__.__name__,
+        #                        self._calendar, other._calendar))  # pragma: no cover
+        #
+        #                return out
+        #            else:
+        #                return False
+        #        # --- End: if
+        #        if not self.isvalid:
+        #            if verbose:
+        #                print(
+        #                    "{}: {!r} is not valid".format(
+        #                        self.__class__.__name__, self)
+        #                )  # pragma: no cover
+        #            return False
+        #
+        #        if not other.isvalid:
+        #            if verbose:
+        #                print(
+        #                    "{}: {!r} is not valid".format(
+        #                        self.__class__.__name__, other)
+        #                )  # pragma: no cover
+        #            return False
+        #
 
-#            utime0 = self._utime
-#            utime1 = other._utime
-#            if utime0 is not None and utime1 is not None:
-#                return utime0.origin_equals(utime1)
-#            elif utime0 is None and utime1 is None:
-#                return self.reftime
-#
-#
-#
-#            units0 = self._units
-#            units1 = other._units
-#            if units0 and units1 or (not units0 and not units1):
-#                out = (self._canonical_calendar == other._canonical_calendar)
-#                if verbose and not out:
-#                    print("{}: Incompatible calendars: {!r}, {!r}".format(
-#                        self.__class__.__name__,
-#                        self._calendar, other._calendar))  # pragma: no cover
-#
-#                return out
-#            else:
-#                return False
-#        # --- End: if
-#        if not self.isvalid:
-#            if verbose:
-#                print(
-#                    "{}: {!r} is not valid".format(
-#                        self.__class__.__name__, self)
-#                )  # pragma: no cover
-#            return False
-#
-#        if not other.isvalid:
-#            if verbose:
-#                print(
-#                    "{}: {!r} is not valid".format(
-#                        self.__class__.__name__, other)
-#                )  # pragma: no cover
-#            return False
-#
-
-#        if not self.isvalid or not other.isvalid:
-#            print ('ppp')
-#            return False
+        #        if not self.isvalid or not other.isvalid:
+        #            print ('ppp')
+        #            return False
 
         if self._units is None and other._units is None:
             # Both units are null and therefore equal (v3.3.1)
@@ -2400,68 +2432,70 @@ class Units():
                 return True
 
             if verbose:
-                print("{}: Different units: {!r}, {!r}".format(
-                    self.__class__.__name__,
-                    self.units, other.units))  # pragma: no cover
+                print(
+                    "{}: Different units: {!r}, {!r}".format(
+                        self.__class__.__name__, self.units, other.units
+                    )
+                )  # pragma: no cover
 
             return False
         except AttributeError:
             return False
 
-#        isreftime1 = self._isreftime
-#        isreftime2 = other._isreftime
-#
-#        if not isreftime1 and not isreftime2:
-#            # Neither units is reference-time so they're equal
-#            return True
-#
-#        if isreftime1 and isreftime2:
-#            # Both units are reference-time
-#            utime0 = self._utime
-#            utime1 = other._utime
-#            if utime0.calendar != utime1.calendar:
-#                return False
-#
-#            return utime0.origin_equals(utime1)
-#
-#        # One unit is a reference-time and the other is not so they're
-#        # not equal
-#        return False
+    #        isreftime1 = self._isreftime
+    #        isreftime2 = other._isreftime
+    #
+    #        if not isreftime1 and not isreftime2:
+    #            # Neither units is reference-time so they're equal
+    #            return True
+    #
+    #        if isreftime1 and isreftime2:
+    #            # Both units are reference-time
+    #            utime0 = self._utime
+    #            utime1 = other._utime
+    #            if utime0.calendar != utime1.calendar:
+    #                return False
+    #
+    #            return utime0.origin_equals(utime1)
+    #
+    #        # One unit is a reference-time and the other is not so they're
+    #        # not equal
+    #        return False
 
     def log(self, base):
-        '''Return the logarithmic unit corresponding to the given logarithmic
-    base.
+        """Return the logarithmic unit corresponding to the given logarithmic
+        base.
 
-    :Parameters:
+        :Parameters:
 
-        base: `int` or `float`
-            The logarithmic base.
+            base: `int` or `float`
+                The logarithmic base.
 
-    :Returns:
+        :Returns:
 
-        `Units`
-            The logarithmic unit corresponding to the given
-            logarithmic base.
+            `Units`
+                The logarithmic unit corresponding to the given
+                logarithmic base.
 
-    **Examples:**
+        **Examples:**
 
-    >>> u = Units('W', names=True)
-    >>> u
-    <Units: watt>
+        >>> u = Units('W', names=True)
+        >>> u
+        <Units: watt>
 
-    >>> u.log(10)
-    <Units: lg(re 1 W)>
-    >>> u.log(2)
-    <Units: lb(re 1 W)>
+        >>> u.log(10)
+        <Units: lg(re 1 W)>
+        >>> u.log(2)
+        <Units: lb(re 1 W)>
 
-    >>> import math
-    >>> u.log(math.e)
-    <Units: ln(re 1 W)>
+        >>> import math
+        >>> u.log(math.e)
+        <Units: ln(re 1 W)>
 
-    >>> u.log(3.5)
-    <Units: 0.798235600147928 ln(re 1 W)>
+        >>> u.log(3.5)
+        <Units: 0.798235600147928 ln(re 1 W)>
 
-        '''
+        """
         try:
             _ut_unit = _ut_log(_c_double(base), self._ut_unit)
         except TypeError:
@@ -2473,12 +2507,16 @@ class Units():
 
         raise ValueError(
             "Can't take the logarithm to the base {!r} of {!r}".format(
-                base, self))
+                base, self
+            )
+        )
+
+
 # --- End: class
 
 
 class Utime(cftime.utime):
-    '''Performs conversions of netCDF time coordinate data to/from
+    """Performs conversions of netCDF time coordinate data to/from
     datetime objects.
 
     This object is (currently) functionally equivalent to a
@@ -2496,33 +2534,37 @@ class Utime(cftime.utime):
     `!units`
     ==============  ==================================================
 
-    '''
-    def __init__(self, calendar, unit_string=None,
-                 only_use_cftime_datetimes=True):
-        '''**Initialization**
+    """
 
-    :Parameters:
+    def __init__(
+        self, calendar, unit_string=None, only_use_cftime_datetimes=True
+    ):
+        """**Initialization**
 
-        calendar: `str`
-            The calendar used in the time calculations. Must be one
-            of: ``'gregorian'``, ``'360_day'``, ``'365_day'``,
-            ``'366_day'``, ``'julian'``, ``'proleptic_gregorian'``,
-            although this is not checked.
+        :Parameters:
 
-        unit_string: `str`, optional
-            A string of the form "time-units since <time-origin>"
-            defining the reference-time units.
+            calendar: `str`
+                The calendar used in the time calculations. Must be one
+                of: ``'gregorian'``, ``'360_day'``, ``'365_day'``,
+                ``'366_day'``, ``'julian'``, ``'proleptic_gregorian'``,
+                although this is not checked.
 
-        only_use_cftime_datetimes: `bool`, optional
-            If False, datetime.datetime objects are returned from
-            `num2date` where possible; By default. dates which
-            subclass `cftime.datetime` are returned for all calendars.
+            unit_string: `str`, optional
+                A string of the form "time-units since <time-origin>"
+                defining the reference-time units.
 
-        '''
+            only_use_cftime_datetimes: `bool`, optional
+                If False, datetime.datetime objects are returned from
+                `num2date` where possible; By default. dates which
+                subclass `cftime.datetime` are returned for all calendars.
+
+        """
         if unit_string:
             super().__init__(
-                unit_string, calendar,
-                only_use_cftime_datetimes=only_use_cftime_datetimes)
+                unit_string,
+                calendar,
+                only_use_cftime_datetimes=only_use_cftime_datetimes,
+            )
         else:
             self.calendar = calendar
             self.origin = None
@@ -2531,9 +2573,7 @@ class Utime(cftime.utime):
             self.units = None
 
     def __repr__(self):
-        '''x.__repr__() <==> repr(x)
-
-        '''
+        """x.__repr__() <==> repr(x)"""
         unit_string = self.unit_string
         if unit_string:
             x = [unit_string]
@@ -2542,35 +2582,36 @@ class Utime(cftime.utime):
 
         x.append(self.calendar)
 
-        return "<Utime: {}>".format(' '.join(x))
+        return "<Utime: {}>".format(" ".join(x))
 
     def num2date(self, time_value):
-        '''Return a datetime-like object given a time value.
+        """Return a datetime-like object given a time value.
 
-    The units of the time value are described by the `!unit_string`
-    and `!calendar` attributes.
+        The units of the time value are described by the `!unit_string`
+        and `!calendar` attributes.
 
-    See `netCDF4.netcdftime.utime.num2date` for details.
+        See `netCDF4.netcdftime.utime.num2date` for details.
 
-    In addition to `netCDF4.netcdftime.utime.num2date`, this method
-    handles units of months and years as defined by Udunits, ie. 1
-    year = 365.242198781 days, 1 month = 365.242198781/12 days.
+        In addition to `netCDF4.netcdftime.utime.num2date`, this method
+        handles units of months and years as defined by Udunits, ie. 1
+        year = 365.242198781 days, 1 month = 365.242198781/12 days.
 
-        '''
+        """
         units = self.units
         unit_string = self.unit_string
 
-        if units in ('month', 'months'):
+        if units in ("month", "months"):
             # Convert months to days
-            unit_string = unit_string.replace(units, 'days', 1)
-            time_value = numpy_array(time_value)*_month_length
-        elif units in ('year', 'years', 'yr'):
+            unit_string = unit_string.replace(units, "days", 1)
+            time_value = numpy_array(time_value) * _month_length
+        elif units in ("year", "years", "yr"):
             # Convert years to days
-            unit_string = unit_string.replace(units, 'days', 1)
-            time_value = numpy_array(time_value)*_year_length
+            unit_string = unit_string.replace(units, "days", 1)
+            time_value = numpy_array(time_value) * _year_length
 
         u = cftime.utime(unit_string, self.calendar)
 
         return u.num2date(time_value)
+
 
 # --- End: class

--- a/cfunits/units.py
+++ b/cfunits/units.py
@@ -765,7 +765,7 @@ class Units:
                 units_split = units.split(" since ")
                 unit = units_split[0].strip()
 
-                _units_since_reftime = unit
+                self._units_since_reftime = unit
 
                 ut_unit = _cached_ut_unit.get(unit, None)
                 if ut_unit is None:

--- a/cfunits/units.py
+++ b/cfunits/units.py
@@ -1,10 +1,6 @@
 import ctypes
 import ctypes.util
-import datetime
 import operator
-import sys
-
-from copy import deepcopy
 
 from numpy import array as numpy_array
 from numpy import asanyarray as numpy_asanyarray
@@ -880,7 +876,7 @@ class Units:
             self._units_since_reftime = None
             try:
                 self._utime = Utime(_canonical_calendar[calendar.lower()])
-            except Exception as error:
+            except Exception:
                 self._new_reason_notvalid(
                     "Invalid calendar={!r}".format(calendar)
                 )

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,63 +18,63 @@ import os
 import datetime
 import cfunits
 
-def _read(fname):
-    """Returns content of a file.
 
-    """
+def _read(fname):
+    """Returns content of a file."""
     fpath = os.path.dirname(__file__)
     fpath = os.path.join(fpath, fname)
-    with open(fpath, 'r') as file_:
+    with open(fpath, "r") as file_:
         return file_.read()
 
-def _get_version():
-    """Returns library version by inspecting __init__.py file.
 
-    """
-    return re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
-                     _read("../../cfunits/__init__.py"),
-                     re.MULTILINE).group(1)
+def _get_version():
+    """Returns library version by inspecting __init__.py file."""
+    return re.search(
+        r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
+        _read("../../cfunits/__init__.py"),
+        re.MULTILINE,
+    ).group(1)
+
 
 def _get_year():
-    '''
-    '''
+    """"""
     return str(datetime.datetime.now().year)
 
-def _get_date():
-    '''Get the current calendar year.
 
-    '''
+def _get_date():
+    """Get the current calendar year."""
     return str(datetime.date.today())
+
 
 # If extensions (or modules to document with autodoc) are in another
 # directory, add these directories to sys.path here. If the directory
 # is relative to the documentation root, use os.path.abspath to make
 # it absolute, like shown here.  sys.path.insert(0,os.path.abspath('.'))
-sys.path.insert(0, os.path.abspath('../..'))
+sys.path.insert(0, os.path.abspath("../.."))
 
 # -- General configuration ----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = '2.3.1'
+needs_sphinx = "2.3.1"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-#   'sphinx.ext.viewcode',
-    'sphinx.ext.linkcode',
-#   'sphinx.ext.pngmath',
-#   'sphinx.ext.mathjax',
-    'sphinx.ext.graphviz',
-#   'sphinx.ext.inheritance_diagram',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.doctest',
-    'sphinx.ext.githubpages',
-    'sphinx_copybutton',
-    'sphinx_toggleprompt',
-    'sphinxcontrib.spelling',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    #   'sphinx.ext.viewcode',
+    "sphinx.ext.linkcode",
+    #   'sphinx.ext.pngmath',
+    #   'sphinx.ext.mathjax',
+    "sphinx.ext.graphviz",
+    #   'sphinx.ext.inheritance_diagram',
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.doctest",
+    "sphinx.ext.githubpages",
+    "sphinx_copybutton",
+    "sphinx_toggleprompt",
+    "sphinxcontrib.spelling",
 ]
 
 # Boolean indicating whether to scan all found documents for
@@ -84,53 +84,54 @@ autosummary_generate = True
 
 # Both the class’ and the __init__ method’s docstring are concatenated
 # and inserted.
-autoclass_content = 'both'
+autoclass_content = "both"
 
-#inheritance_graph_attrs = {'rankdir': "TB",
+# inheritance_graph_attrs = {'rankdir': "TB",
 #                           'clusterrank': 'local'}
-#inheritance_node_attrs  = {'style': 'filled'}
+# inheritance_node_attrs  = {'style': 'filled'}
 
 # This value selects how automatically documented members are sorted
 # (http://sphinx-doc.org/latest/ext/autodoc.html)
-autodoc_member_order = 'groupwise'
+autodoc_member_order = "groupwise"
 
 # This value is a list of autodoc directive flags that should be
 # automatically applied to all autodoc
 # directives. (http://sphinx-doc.org/latest/ext/autodoc.html)
-autodoc_default_options = {'members': True,
-                           'inherited-members': True,
-                           'show-inheritance': True,
+autodoc_default_options = {
+    "members": True,
+    "inherited-members": True,
+    "show-inheritance": True,
 }
 
-intersphinx_cache_limit = 5     # days to keep the cached inventories
+intersphinx_cache_limit = 5  # days to keep the cached inventories
 intersphinx_mapping = {
-    'sphinx':     ('http://sphinx.pocoo.org',  None),
-    'python':     ('http://docs.python.org/3', None),
-    'numpy':      ('http://docs.scipy.org/doc/numpy', None),
-    'cftime':     ('http://unidata.github.io/cftime', None),
-    }
+    "sphinx": ("http://sphinx.pocoo.org", None),
+    "python": ("http://docs.python.org/3", None),
+    "numpy": ("http://docs.scipy.org/doc/numpy", None),
+    "cftime": ("http://unidata.github.io/cftime", None),
+}
 
 # The name of the default domain. Can also be None to disable a
 # default domain. The default is 'py'.
-#primary_domain = 'cfunits'
+# primary_domain = 'cfunits'
 
 # Add any paths that contain templates here, relative to this directory.
-#templates_path = ['_templates', '../_templates', '../../_templates']
-templates_path = ['../_templates']
+# templates_path = ['_templates', '../_templates', '../../_templates']
+templates_path = ["../_templates"]
 
 # The suffix of source filenames.
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The encoding of source files.
-#source_encoding = 'utf-8-sig'
+# source_encoding = 'utf-8-sig'
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = u'Python cfunits package'
-copyright = _get_year()+', NCAS | Page built on '+_get_date()
-author = 'David Hassell'
+project = u"Python cfunits package"
+copyright = _get_year() + ", NCAS | Page built on " + _get_date()
+author = "David Hassell"
 
 # The version info for the project you're documenting, acts as
 # replacement for |version| and |release|, also used in various other
@@ -143,21 +144,21 @@ release = _get_version()
 
 # The language for content autogenerated by Sphinx. Refer to
 # documentation for a list of supported languages.
-#language = None
+# language = None
 
 # There are two options for replacing |today|: either, you set today
 # to some non-false value, then it is used:
-#today = ''
-#Else, today_fmt is used as the format for a strftime call.
-#today_fmt = '%B %d, %Y'
+# today = ''
+# Else, today_fmt is used as the format for a strftime call.
+# today_fmt = '%B %d, %Y'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 exclude_patterns = []
 
 # The reST default role (used for this markup: `text`) to use for all
-#documents.
-#default_role = None
+# documents.
+# default_role = None
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 add_function_parentheses = False
@@ -168,49 +169,49 @@ add_module_names = True
 
 # If true, sectionauthor and moduleauthor directives will be shown in
 # the output. They are ignored by default.
-show_authors = True # False
+show_authors = True  # False
 
 # The name of the Pygments (syntax highlighting) style to use.
-#pygments_style = 'sphinx'
+# pygments_style = 'sphinx'
 
 # The default language to highlight source code
-highlight_language = 'python'
+highlight_language = "python"
 
 # A list of ignored prefixes for module index sorting.
-#modindex_common_prefix = []
+# modindex_common_prefix = []
 
 
 # -- Options for HTML output --------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the
 # documentation for a list of builtin themes.
-#html_theme = 'default'
-html_theme = 'alabaster' #'default' #'haiku' #'default'
+# html_theme = 'default'
+html_theme = "alabaster"  #'default' #'haiku' #'default'
 
 # Theme options are theme-specific and customize the look and feel of
 # a theme further.  For a list of options available for each theme,
 # see the documentation.
 html_theme_options = {
-    "show_related"    : 'true',
-    "sidebar_collapse": 'true',
-    'fixed_sidebar'   : 'true',
-    'page_width'      : '85%',
-    'seealso_bg'      : 'transparent',
-    'seealso_border'  : 'transparent',
-    'shadow'          : 'false',
-     'show_powered_by': 'true',
-    'font_size'       : '13pt',
-    'code_font_size'  : '10pt',
-    'font_family'     : 'Arial',
-    'head_font_family': 'Arial',
-    'link_hover'      : '#6b0000',
-    'github_button'   : 'true',
-    'github_type'     : 'star',
-    'github_repo'     : 'cfunits',
-    'github_user'     : 'NCAS-CMS',
-    'pre_bg'          : '#ecf2f9',
-    'code_bg'         : '#ecf2f9',
-    'description'     : 'A Python interface to the UDUNITS-2 library with CF extensions',
+    "show_related": "true",
+    "sidebar_collapse": "true",
+    "fixed_sidebar": "true",
+    "page_width": "85%",
+    "seealso_bg": "transparent",
+    "seealso_border": "transparent",
+    "shadow": "false",
+    "show_powered_by": "true",
+    "font_size": "13pt",
+    "code_font_size": "10pt",
+    "font_family": "Arial",
+    "head_font_family": "Arial",
+    "link_hover": "#6b0000",
+    "github_button": "true",
+    "github_type": "star",
+    "github_repo": "cfunits",
+    "github_user": "NCAS-CMS",
+    "pre_bg": "#ecf2f9",
+    "code_bg": "#ecf2f9",
+    "description": "A Python interface to the UDUNITS-2 library with CF extensions",
 }
 
 # The name for this set of Sphinx documents.  If None, it defaults to
@@ -219,49 +220,51 @@ html_title = "Documentation"
 
 # A shorter title for the navigation bar.  Default is the same as
 # html_title.
-#html_short_title = None
+# html_short_title = None
 
 # The name of an image file (relative to this directory) to place at
 # the top of the sidebar.
-#html_logo = None
+# html_logo = None
 
 # The name of an image file (within the static path) to use as favicon
 # of the docs.  This file should be a Windows icon file (.ico) being
 # 16x16 or 32x32 pixels large.
-#html_favicon = None
+# html_favicon = None
 
 # Add any paths that contain custom static files (such as style
 # sheets) here, relative to this directory. They are copied after the
 # builtin static files, so a file named "default.css" will overwrite
 # the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 # Paths (filenames) here must be relative to (under) html_static_path as above:
 html_css_files = [
-    'customise-alabaster.css',
+    "customise-alabaster.css",
 ]
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page
 # bottom, using the given strftime format.
-html_last_updated_fmt = '%b %d, %Y'
+html_last_updated_fmt = "%b %d, %Y"
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
 html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-#html_sidebars = {'**': ['my_con.html', 'globaltoc.html', 'sourcelink.html']}
-html_sidebars = { '**': ['about.html',
-                         'searchbox.html',
-                         'globaltoc.html',
-                         'relations.html',
-#                         'sourcelink.html',
-                         ]
+# html_sidebars = {'**': ['my_con.html', 'globaltoc.html', 'sourcelink.html']}
+html_sidebars = {
+    "**": [
+        "about.html",
+        "searchbox.html",
+        "globaltoc.html",
+        "relations.html",
+        #                         'sourcelink.html',
+    ]
 }
 
 # Additional templates that should be rendered to pages, maps page
 # names to template names.
-#html_additional_pages = {}
+# html_additional_pages = {}
 
 # If false, no module index is generated.
 html_domain_indices = True
@@ -277,43 +280,42 @@ html_show_sourcelink = False
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default
 # is True.
-#html_show_sphinx = True
+# html_show_sphinx = True
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is
 # True.
-#html_show_copyright = True
+# html_show_copyright = True
 
 # If true, an OpenSearch description file will be output, and all
 # pages will contain a <link> tag referring to it.  The value of this
 # option must be the base URL from which the finished HTML is served.
-#html_use_opensearch = ''
+# html_use_opensearch = ''
 
 # This is the file name suffix for HTML files (e.g. ".xhtml").
-#html_file_suffix = None
+# html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'cfunitsdoc'
+htmlhelp_basename = "cfunitsdoc"
 
 
 # -- Options for LaTeX output -------------------------------------------------
 
 ## The paper size ('letter' or 'a4').
-#latex_paper_size = 'a4'
+# latex_paper_size = 'a4'
 
 # The font size ('10pt', '11pt' or '12pt').
-#latex_font_size = '10pt'
+# latex_font_size = '10pt'
 
 # Grouping the document tree into LaTeX files. List of tuples (source
 # start file, target name, title, author, documentclass
 # [howto/manual]).
 latex_documents = [
-    ('index', 'cfunits.tex', 'cfunits Documentation',
-     'NCAS', 'manual'),
-    ]
+    ("index", "cfunits.tex", "cfunits Documentation", "NCAS", "manual"),
+]
 
 # The name of an image file (relative to this directory) to place at
 # the top of the title page.
-#latex_logo = None
+# latex_logo = None
 
 # For "manual" documents, if this is true, then toplevel headings are
 # parts, not chapters.
@@ -323,44 +325,41 @@ latex_use_parts = True
 latex_show_pagerefs = False
 
 # If true, show URL addresses after external links.
-latex_show_urls = 'footnote'
+latex_show_urls = "footnote"
 
 # Additional stuff for the LaTeX preamble.
-#latex_preamble = ''
+# latex_preamble = ''
 
 # Documents to append as an appendix to all manuals.
-#latex_appendices = []
+# latex_appendices = []
 
 # If false, no module index is generated.
 latex_domain_indices = True
 
 # A dictionary that contains LaTeX snippets that override those Sphinx
 # usually puts into the generated .tex files.
-latex_elements = {'papersize': 'a4paper'}
+latex_elements = {"papersize": "a4paper"}
 
 # -- Options for manual page output -------------------------------------------
 
 # One entry per manual page. List of tuples (source start file, name,
 # description, authors, manual section).
-man_pages = [
-    ('index', 'cfunits', 'cfunits Documentation',
-     'NCAS', 1)
-    ]
+man_pages = [("index", "cfunits", "cfunits Documentation", "NCAS", 1)]
 
 # Configure copybutton
 # Note the below, skipping of text via copybutton, is no longer required for
 # Python prompts as those can be included or excluded in copied code via the
 # toggle button (sphinx-toggleprompt). So we skip console prompts which we
 # also have in the docs as the second most-common case.
-copybutton_prompt_text = "$ "   # prompt to skip automatically on copying
+copybutton_prompt_text = "$ "  # prompt to skip automatically on copying
 
 # Configure toggleprompt
 toggleprompt_offset_right = 25  # stops toggle and copy buttons overlapping
 
 # Spelling extension configuration: set British English and false positives
-spelling_lang = 'en_GB'
-tokenizer_lang = 'en_GB'
-spelling_word_list_filename = 'spelling_false_positives.txt'
+spelling_lang = "en_GB"
+tokenizer_lang = "en_GB"
+spelling_word_list_filename = "spelling_false_positives.txt"
 
 # This is a function which should return the URL to source code
 # corresponding to the object in given domain with given information.
@@ -368,67 +367,69 @@ spelling_word_list_filename = 'spelling_false_positives.txt'
 import inspect
 from os.path import relpath, dirname
 
-link_release = re.search('(\d+\.\d+\.\d+)', release).groups()[0]
+link_release = re.search("(\d+\.\d+\.\d+)", release).groups()[0]
+
 
 def linkcode_resolve(domain, info):
-    
-    #=================================================================
+
+    # =================================================================
     # Must delete all .doctrees directories in build for changes to be
     # picked up. E.g.:
     #
     # >> rm -fr build/.doctrees build/*/.doctrees build/*/*/.doctrees
-    #=================================================================
+    # =================================================================
 
     online_source_code = True
 
-    if domain != 'py':
+    if domain != "py":
         return None
-    if not info['module']:
+    if not info["module"]:
         return None
-    
-    modname = info['module']
-    fullname = info['fullname']
-    
+
+    modname = info["module"]
+    fullname = info["fullname"]
+
     submod = sys.modules.get(modname, None)
     if submod is None:
         return None
-    
+
     obj = submod
-    for part in fullname.split('.'):
+    for part in fullname.split("."):
         try:
             obj = getattr(obj, part)
         except:
             return None
-    
+
     try:
         fn = inspect.getsourcefile(obj)
     except:
         fn = None
     if not fn:
         return None
-    
+
     try:
         source, lineno = inspect.findsource(obj)
         nlines = len(inspect.getsourcelines(obj)[0])
     except:
         lineno = None
-    
+
     fn = relpath(fn, start=dirname(cfunits.__file__))
-    
+
     if lineno:
-        linespec = "#L{0}".format(lineno+1)
+        linespec = "#L{0}".format(lineno + 1)
         # Can add range when jump-to feature is enable in bitbucket
     else:
         linespec = ""
-    
+
     # ----------------------------------------------------------------
     # NOTE: You need to touch the .rst files to get the change in
     # ----------------------------------------------------------------
     if online_source_code:
-         url = "https://github.com/NCAS-CMS/cfunits/blob/v{0}/cfunits/{1}{2}".format(
-             link_release, fn, linespec)
-         print(url)
-         return url
+        url = "https://github.com/NCAS-CMS/cfunits/blob/v{0}/cfunits/{1}{2}".format(
+            link_release, fn, linespec
+        )
+        print(url)
+        return url
     else:
         # Point to local source code relative to this directory
         return "../../../cfunits/%s%s" % (fn, linespec)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -186,7 +186,7 @@ highlight_language = "python"
 # The theme to use for HTML and HTML Help pages.  See the
 # documentation for a list of builtin themes.
 # html_theme = 'default'
-html_theme = "alabaster"  #'default' #'haiku' #'default'
+html_theme = "alabaster"
 
 # Theme options are theme-specific and customize the look and feel of
 # a theme further.  For a list of options available for each theme,
@@ -300,7 +300,7 @@ htmlhelp_basename = "cfunitsdoc"
 
 # -- Options for LaTeX output -------------------------------------------------
 
-## The paper size ('letter' or 'a4').
+# The paper size ('letter' or 'a4').
 # latex_paper_size = 'a4'
 
 # The font size ('10pt', '11pt' or '12pt').
@@ -367,7 +367,7 @@ spelling_word_list_filename = "spelling_false_positives.txt"
 import inspect
 from os.path import relpath, dirname
 
-link_release = re.search("(\d+\.\d+\.\d+)", release).groups()[0]
+link_release = re.search(r"(\d+\.\d+\.\d+)", release).groups()[0]
 
 
 def linkcode_resolve(domain, info):
@@ -409,7 +409,6 @@ def linkcode_resolve(domain, info):
 
     try:
         source, lineno = inspect.findsource(obj)
-        nlines = len(inspect.getsourcelines(obj)[0])
     except:
         lineno = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+# This file is currently used only to configure the black Python code
+# formatter, rather than provide project metadata (see
+# https://www.python.org/dev/peps/pep-0621/) which can be found instead
+# in the setup.py file.
+
+# To run the black checker with this configuration, execute 'black .' in the
+# root of this repository. See https://black.readthedocs.io/en/stable/ for
+# the 'black' documentation.
+[tool.black]
+line-length = 79

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,6 @@
-from distutils.core import setup, Extension
-from distutils.command.build import build
+from distutils.core import setup
 import os
 import fnmatch
-import sys
-import imp
 import re
 
 

--- a/setup.py
+++ b/setup.py
@@ -6,38 +6,40 @@ import sys
 import imp
 import re
 
+
 def find_package_data_files(directory):
     for root, dirs, files in os.walk(directory):
         for basename in files:
-            if fnmatch.fnmatch(basename, '*'):
+            if fnmatch.fnmatch(basename, "*"):
                 filename = os.path.join(root, basename)
-                yield filename.replace('cfunits/', '', 1)
+                yield filename.replace("cfunits/", "", 1)
+
 
 def _read(fname):
-    """Returns content of a file.
-
-    """
+    """Returns content of a file."""
     fpath = os.path.dirname(__file__)
     fpath = os.path.join(fpath, fname)
-    with open(fpath, 'r') as file_:
+    with open(fpath, "r") as file_:
         return file_.read()
 
-def _get_version():
-    """Returns library version by inspecting __init__.py file.
 
-    """
-    return re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
-                     _read("cfunits/__init__.py"),
-                     re.MULTILINE).group(1)
-      
-version      = _get_version()
-packages     = ['cfunits']
-etc_files    = [f for f in find_package_data_files('cfunits/etc')]
-test_files    = [f for f in find_package_data_files('cfunits/test')]
+def _get_version():
+    """Returns library version by inspecting __init__.py file."""
+    return re.search(
+        r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
+        _read("cfunits/__init__.py"),
+        re.MULTILINE,
+    ).group(1)
+
+
+version = _get_version()
+packages = ["cfunits"]
+etc_files = [f for f in find_package_data_files("cfunits/etc")]
+test_files = [f for f in find_package_data_files("cfunits/test")]
 
 package_data = etc_files + test_files
 
-#with open('README.md') as ldfile:
+# with open('README.md') as ldfile:
 #    long_description = ldfile.read()
 
 long_description = """*A python interface to UNIDATA's UDUNITS-2 library with CF
@@ -73,32 +75,44 @@ https://ncas-cms.github.io/cfunits/installation.html
 # classifiers list at: https://pypi.python.org/pypi?%3Aaction=list_classifiers
 
 # Get dependencies
-requirements = open('requirements.txt', 'r')
-install_requires = requirements.read().splitlines() 
+requirements = open("requirements.txt", "r")
+install_requires = requirements.read().splitlines()
 
-setup(name = "cfunits",
-      long_description = long_description,
-      version      = version,
-      description  = "A python interface to UNIDATA's UDUNITS-2 package with CF extensions ",
-      maintainer   = "David Hassell",
-      author       = "David Hassell",
-      maintainer_email = "david.hassell@ncas.ac.uk",
-      author_email = "david.hassell@ncas.ac.uk",
-      url          = "https://bitbucket.org/cfpython/cfunits-python",
-      download_url = "https://bitbucket.org/cfpython/cfunits-python/downloads",
-      platforms    = ["Linux", "MacOS"],
-      license      = ["MIT"],
-      keywords     = ['cf', 'udunits', 'UNIDATA', 'netcdf','data',
-                      'science', 'oceanography', 'meteorology', 'climate'],
-      classifiers  = ["Development Status :: 5 - Production/Stable",
-                      "Intended Audience :: Science/Research", 
-                      "License :: OSI Approved :: MIT License", 
-                      "Topic :: Scientific/Engineering",
-                      "Operating System :: MacOS",
-                      "Operating System :: POSIX :: Linux",
-                      "Programming Language :: Python :: 3",],
-      packages     = ['cfunits'],
-      package_data = {'cfunits': package_data},
-      python_requires='>=3.6',
-      install_requires = install_requires,
-  )
+setup(
+    name="cfunits",
+    long_description=long_description,
+    version=version,
+    description="A python interface to UNIDATA's UDUNITS-2 package with CF extensions ",
+    maintainer="David Hassell",
+    author="David Hassell",
+    maintainer_email="david.hassell@ncas.ac.uk",
+    author_email="david.hassell@ncas.ac.uk",
+    url="https://bitbucket.org/cfpython/cfunits-python",
+    download_url="https://bitbucket.org/cfpython/cfunits-python/downloads",
+    platforms=["Linux", "MacOS"],
+    license=["MIT"],
+    keywords=[
+        "cf",
+        "udunits",
+        "UNIDATA",
+        "netcdf",
+        "data",
+        "science",
+        "oceanography",
+        "meteorology",
+        "climate",
+    ],
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: MIT License",
+        "Topic :: Scientific/Engineering",
+        "Operating System :: MacOS",
+        "Operating System :: POSIX :: Linux",
+        "Programming Language :: Python :: 3",
+    ],
+    packages=["cfunits"],
+    package_data={"cfunits": package_data},
+    python_requires=">=3.6",
+    install_requires=install_requires,
+)


### PR DESCRIPTION
Set up the use of pre-commit hooks to lint any Python modules (only) in the codebase for validity, formatting and style issues so they are raised and can be amended before they can be committed, with an initial sweep of the codebase with these tools so all modules are up-to-standard by the same criteria to begin with.

This way the codebase is and should remain free of any such issues, though note I have left in (untouched) the `test_style.py` test in the test suite in order to confirm we abide by vanilla PEP8 via running the `pycodestyle` check (I would have added in `black` and/or `flake8` checks in new methods to this test module, but it seems these are designed for the CLI only since, despite being Python libraries, from interactive inspection and searching online they seem to have made it as difficult as possible, and not documented how, to run the checks programmatically in Python itself :grimacing:).

The new linting tools used are:

* [black](https://black.readthedocs.io/en/stable/) to format in, and validate for, a categorical styling that abides by PEP8 but constrains remaining degrees of freedom e.g. to enforce certain means of wrapping lines;
* [flake8](https://flake8.pycqa.org/en/latest/index.html) for further checks such as unused variables and imports, malformed format strings, complexity etc.; 
* a small number of other [core library pre-commit hooks](pre-commit.com) that look useful for validation on good formatting, e.g. parsing the files as valid Python, checking for trailing whitespatoce (see the [master listing here](https://github.com/pre-commit/pre-commit-hooks#hooks-available) which I chose appropriate ones from).

****

### Notes on pre-commit hooks

@davidhassell the details above aren't important (unless you are especially interested!) but do be aware that this PR sets up pre-commit hooks which means that, after it is merged, any attempt to make a commit locally will initiate some checks on files that have been changed and staged, the output of which looks similar to this:

```console
$ git commit -m "Fix issues raised by flake8 excluding skip and potential bug"
[WARNING] Unstaged files detected.
[INFO] Stashing unstaged files to /home/sadie/.cache/pre-commit/patch1610396726.
Check python ast.........................................................Passed
Debug Statements (Python)................................................Passed
Fix End of Files.........................................................Passed
Trim Trailing Whitespace.................................................Passed
black....................................................................Passed
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

cfunits/units.py:768:17: F841 local variable '_units_since_reftime' is assigned to but never used
```

If they pass, the commit is made as standard, but if at least one check fails then the commit will not be made until any issues raised are fixed. Some feedback should be given to indicate what needs to be done.

Note you will need to install the tools, e.g. this does it:

```console
$ pip install pre-commit
$ pip install black
$ pip install flake8
```

and additionally on any machine used to commit to the repo, first run:

```console
$ pre-commit install
```

to process the pre-commit configuration file which install the hooks to enable those checks to run all the time (it seems to re-run on start-up so no need to running that one every day).

*Tip*: if (as I often do in) you want to make "dev" commits which may be squashed or discarded later, i.e. not intended as a formal commit that will be pushed, you can skip all those checks with the `--no-verify` option to `git commit`. Though I think we should try to avoid using that to skip the checks unless we know we won't be pushing the commit in question in the same form.