### PR TITLE
Post-commit linting via new Actions workflow

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -30,5 +30,15 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: psf/black@stable
 
-  # TODO: pre-commit hook linting, flake8 linting, docstyle linting (both
-  # pydocstyle and docformatter if possible, if not one or something similar).
+  # Lint against selected pre-commit hooks (see https://pre-commit.com
+  # and https://github.com/pre-commit/action).
+  # *Keep the config. here the same as that in the .pre-commit-config.yaml*
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.0
+
+  # TODO: flake8 linting, docstyle linting (both pydocstyle and docformatter
+  # if possible, if not one or something similar).

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -40,18 +40,23 @@ jobs:
     - uses: actions/setup-python@v2
     - uses: pre-commit/action@v2.0.0
 
-  # Lint with flake8 (see https://github.com/julianwachholz/flake8-action)
+  # Lint with flake8 (see https://github.com/suo/flake8-github-action)
   # *Keep the config. here the same as that in the .flake8 file*
   flake8:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - uses: julianwachholz/flake8-action@v1.1.0
+        uses: actions/setup-python@v1
         with:
-          checkName: lint
-          isTest: true
-        env:  # A token is required but GitHub manages it all automatically
+          python-version: 3.8
+      - name: Checkout PyTorch
+        uses: actions/checkout@master
+      - name: Install flake8
+        run: pip install flake8
+      - name: Run flake8
+        uses: suo/flake8-github-action@releases/v1
+        with:  # A token is required but GitHub manages it all automatically
+          checkName: 'flake8'
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
   # TODO: docstyle linting (both pydocstyle and docformatter

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,34 @@
+name: Linting
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    # default (from docs) is just on [opened, synchronize, reopened]
+    types: [opened, reopened, ready_for_review, edited]
+    branches:
+      - master
+
+# Note: only running this on Ubuntu (latest) and Python 3.7 as representative,
+# since the linting output should be machine dependent and not vary much if
+# at all by Python minor version.
+
+jobs:
+  # Note: ensure the configuration for each linter used (i.e. each job)
+  # corresponds to that configured by the .pre-commit-config.yaml else
+  # we will be linting on different requirements pre- and post- commit!
+
+  # Lint with black (see https://black.readthedocs.io/en/stable/index.html)
+  # where the black config. in pyproject.toml should be detected and applied on
+  # the black command used to lint the codebase.
+  # *Keep the config. here the same as that in the pyproject.toml*
+  black:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: psf/black@stable
+
+  # TODO: pre-commit hook linting, flake8 linting, docstyle linting (both
+  # pydocstyle and docformatter if possible, if not one or something similar).

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -10,7 +10,7 @@ on:
     branches:
       - master
 
-# Note: only running this on Ubuntu (latest) and Python 3.7 as representative,
+# Note: only running this on Ubuntu (latest) and Python 3.8 as representative,
 # since the linting output should be machine dependent and not vary much if
 # at all by Python minor version.
 
@@ -22,7 +22,7 @@ jobs:
   # Lint with black (see https://black.readthedocs.io/en/stable/index.html)
   # where the black config. in pyproject.toml should be detected and applied on
   # the black command used to lint the codebase.
-  # *Keep the config. here the same as that in the pyproject.toml*
+  # *Keep the config. here the same as that in the pyproject.toml file*
   black:
     runs-on: ubuntu-latest
     steps:
@@ -40,5 +40,19 @@ jobs:
     - uses: actions/setup-python@v2
     - uses: pre-commit/action@v2.0.0
 
-  # TODO: flake8 linting, docstyle linting (both pydocstyle and docformatter
+  # Lint with flake8 (see https://github.com/julianwachholz/flake8-action)
+  # *Keep the config. here the same as that in the .flake8 file*
+  flake8:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: julianwachholz/flake8-action@v1.1.0
+        with:
+          checkName: lint
+          isTest: true
+        env:  # A token is required but GitHub manages it all automatically
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+  # TODO: docstyle linting (both pydocstyle and docformatter
   # if possible, if not one or something similar).


### PR DESCRIPTION
Pre-commit linting is now in-place after #21 and #22 but I will also add a new GH Actions workflow to do the equivalent linting on the codebase, effectively post-commit, since pre-commit hooks can be skipped meaning they don't ensure the new state of the codebase is passing the linting.

The workflow configuration is consistent with the pre-commit configuration of each linter applied, and it must remain so (I have commented as such in the new workflow file).

I've used a separate workflow to the existing one, `run-test-suite.yml`, since:

* linting does not require much setup at all, whereas running the test suite requires all the module dependencies and testing libraries to be installed correctly, etc.;
* linting is a distinct form of testing, so it would be good to keep it segregated from the other, e.g. unit, testing.

Note: I am adding sections in incrementally in the PR so I can check stages work and keep the trail-and-error contained.