### PR TITLE
Apply & add hook for `isort` (systematic import sorting)

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -20,8 +20,8 @@ jobs:
   # *The config. applied here is from our .pre-commit-config.yaml*
   #
   # Note the pre-commit linting includes all of the other linters configured
-  # to run as pre-commit hooks, namely black, flake8, docformatter and
-  # pydocstyle, so there is no need to set these up individually!
+  # to run as pre-commit hooks, namely black, flake8 and docformatter etc.,
+  # so there is no need to set these up individually!
   pre-commit:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,3 +60,19 @@ repos:
     rev: 3.9.1
     hooks:
       - id: flake8
+
+  # Apply the 'isort' tool (fully compatible with 'black' after version 5
+  # which we surpass) to sort Python import statements systematically
+  # (see https://pycqa.github.io/isort/ for documentation). No further
+  # configuration is applied, nor required, than the below for a hook.
+  - repo: https://github.com/pycqa/isort
+    rev: 5.8.0
+    hooks:
+      - id: isort
+        name: isort (python)
+      - id: isort
+        name: isort (cython)
+        types: [cython]
+      - id: isort
+        name: isort (pyi)
+        types: [pyi]

--- a/cfunits/__init__.py
+++ b/cfunits/__init__.py
@@ -19,8 +19,8 @@ __date__ = "2021-05-21"
 __version__ = "3.3.3"
 __cf_version__ = "1.8"
 
-from distutils.version import LooseVersion
 import platform
+from distutils.version import LooseVersion
 
 try:
     import cftime

--- a/cfunits/test/run_tests.py
+++ b/cfunits/test/run_tests.py
@@ -1,17 +1,16 @@
 from __future__ import print_function
 
-import unittest
+import datetime
 import doctest
-import pkgutil
-from platform import platform, python_version
+import faulthandler
 import os
-from random import choice
+import pkgutil
 import sys
+import unittest
+from platform import platform, python_version
+from random import choice
 
 import numpy
-import datetime
-
-import faulthandler
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cfunits/test/test_Units.py
+++ b/cfunits/test/test_Units.py
@@ -1,10 +1,9 @@
+import faulthandler
 import math
 import os
 import unittest
 
 import numpy
-
-import faulthandler
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cfunits/test/test_style.py
+++ b/cfunits/test/test_style.py
@@ -1,8 +1,8 @@
+import faulthandler
 import os
-import pycodestyle
 import unittest
 
-import faulthandler
+import pycodestyle
 
 faulthandler.enable()  # to debug seg faults and timeouts
 

--- a/cfunits/units.py
+++ b/cfunits/units.py
@@ -10,7 +10,6 @@ from numpy import ndarray as numpy_ndarray
 from numpy import shape as numpy_shape
 from numpy import size as numpy_size
 
-
 # --------------------------------------------------------------------
 # Aliases for ctypes
 # --------------------------------------------------------------------
@@ -290,7 +289,6 @@ add_unit_alias("10 dB", None, "bel", "bels")
 
 from cftime import _dateparse as cftime_dateparse
 from cftime import datetime as cftime_datetime
-
 
 _cached_ut_unit = {}
 _cached_utime = {}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,10 +12,11 @@
 # All configuration values have a default; values that are commented
 # out serve to show the default.
 
+import datetime
+import os
 import re
 import sys
-import os
-import datetime
+
 import cfunits
 
 
@@ -365,7 +366,7 @@ spelling_word_list_filename = "spelling_false_positives.txt"
 # corresponding to the object in given domain with given information.
 
 import inspect
-from os.path import relpath, dirname
+from os.path import dirname, relpath
 
 link_release = re.search(r"(\d+\.\d+\.\d+)", release).groups()[0]
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
-from setuptools import setup
-import os
 import fnmatch
+import os
 import re
+
+from setuptools import setup
 
 
 def find_package_data_files(directory):


### PR DESCRIPTION
As per title description. No functional changes made, just automatic re-organisation of import statments. See NCAS-CMS/cf-python#63 for context: I am adding PRs now to apply `isort` across `cfunits`, `cfdm` and `cf-python` in turn.