### PR TITLE
ubuntu 16.04 reached EoL, therefore switch github action to ubuntu 18.04 in that case

### DIFF
--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -19,7 +19,7 @@ jobs:
     # Set-up the build matrix. We run on different distros and Python versions.
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-16.04, macos-latest, macos-10.15]
+        os: [ubuntu-latest, ubuntu-18.04, macos-latest, macos-10.15]
         python-version: [3.6, 3.7, 3.8, 3.9]
 
     # Run on new and old(er) versions of the distros we support (Linux, Mac OS)

--- a/.github/workflows/run-test-suite_ubuntu_default_packages.yml
+++ b/.github/workflows/run-test-suite_ubuntu_default_packages.yml
@@ -30,13 +30,16 @@ jobs:
       run: lsb_release -a
     - name: check python version
       run: python3 -V
+    # update ubuntu repositories
+    - name: apt-get update
+      run: sudo apt-get update
     # install dependencies
     - name: install dependencies (ubuntu 18.04 packages)
       if: matrix.os == 'ubuntu-18.04'
-      run: sudo apt install python3-setuptools python3-wheel libudunits2-0 python3-pycodestyle python3-coverage
+      run: sudo apt-get install python3-setuptools python3-wheel libudunits2-0 python3-pycodestyle python3-coverage
     - name: install dependencies (ubuntu 20.04 packages)
       if: matrix.os == 'ubuntu-20.04'
-      run: sudo apt install python3-setuptools python3-wheel libudunits2-0 python3-pycodestyle python3-coverage python3-numpy
+      run: sudo apt-get install python3-setuptools python3-wheel libudunits2-0 python3-pycodestyle python3-coverage python3-numpy
     # Install cfunits
     # Important! Must install our development version of cfunits to test:
     # pip install -e .


### PR DESCRIPTION
Since [ubuntu 16.04](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1604-README.md) reached EoL (see actions/virtual-environments#3287), we have to switch the github action [run-test-suite.yml](.github/workflows/run-test-suite.yml) to [ubuntu 18.04](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md).