### PR TITLE
Actions: manage failing `cftime` dist. build w/ Ubuntu 18.04

### DIFF
--- a/.github/workflows/run-test-suite_ubuntu_default_packages.yml
+++ b/.github/workflows/run-test-suite_ubuntu_default_packages.yml
@@ -42,11 +42,10 @@ jobs:
       run: sudo apt-get install python3-setuptools python3-wheel libudunits2-0 python3-pycodestyle python3-coverage python3-numpy
     - name: install cfunits (ubuntu 18.04)
       if: matrix.os == 'ubuntu-18.04'
-      # Must upgrade and use a pip version of setuptools because the dist.
-      # config. of cftime=1.5.0 has a key set that fails to be built and
-      # causes an overall error with older setuptools.
+      # Config. of cftime=1.5.0 has a key set that fails to be built and
+      # causes an overall error with older setuptools get here, so bypass.
       run: |
-        pip3 install --upgrade setuptools
+        pip3 install cftime==1.5.1 --only-binary
         pip3 install -e .
     - name: install cfunits (ubuntu 20.04)
       if: matrix.os == 'ubuntu-20.04'

--- a/.github/workflows/run-test-suite_ubuntu_default_packages.yml
+++ b/.github/workflows/run-test-suite_ubuntu_default_packages.yml
@@ -45,7 +45,7 @@ jobs:
       # Config. of cftime=1.5.0 has a key set that fails to be built and
       # causes an overall error with older setuptools get here, so bypass.
       run: |
-        pip3 install cftime==1.5.1
+        python3 -m pip install --upgrade setuptools
         pip3 install -e .
     - name: install cfunits (ubuntu 20.04)
       if: matrix.os == 'ubuntu-20.04'

--- a/.github/workflows/run-test-suite_ubuntu_default_packages.yml
+++ b/.github/workflows/run-test-suite_ubuntu_default_packages.yml
@@ -45,7 +45,7 @@ jobs:
       # Config. of cftime=1.5.0 has a key set that fails to be built and
       # causes an overall error with older setuptools get here, so bypass.
       run: |
-        pip3 install cftime==1.5.1 --only-binary
+        pip3 install cftime==1.5.1
         pip3 install -e .
     - name: install cfunits (ubuntu 20.04)
       if: matrix.os == 'ubuntu-20.04'

--- a/.github/workflows/run-test-suite_ubuntu_default_packages.yml
+++ b/.github/workflows/run-test-suite_ubuntu_default_packages.yml
@@ -40,12 +40,14 @@ jobs:
     - name: install dependencies (ubuntu 20.04 packages)
       if: matrix.os == 'ubuntu-20.04'
       run: sudo apt-get install python3-setuptools python3-wheel libudunits2-0 python3-pycodestyle python3-coverage python3-numpy
-    # Install cfunits
-    # Important! Must install our development version of cfunits to test:
-    # pip install -e .
     - name: install cfunits (ubuntu 18.04)
       if: matrix.os == 'ubuntu-18.04'
-      run: pip3 install -e .
+      # Must upgrade and use a pip version of setuptools because the dist.
+      # config. of cftime=1.5.0 has a key set that fails to be built and
+      # causes an overall error with older setuptools.
+      run: |
+        pip3 install --upgrade setuptools
+        pip3 install -e .
     - name: install cfunits (ubuntu 20.04)
       if: matrix.os == 'ubuntu-20.04'
       # https://github.com/pypa/pip/issues/7953

--- a/.github/workflows/run-test-suite_ubuntu_default_packages.yml
+++ b/.github/workflows/run-test-suite_ubuntu_default_packages.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md
         # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-20.04,]  # TODO reinstate'ubuntu-18.04' job by uncommenting
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -34,19 +34,17 @@ jobs:
     - name: apt-get update
       run: sudo apt-get update
     # install dependencies
-    - name: install dependencies (ubuntu 18.04 packages)
-      if: matrix.os == 'ubuntu-18.04'
-      run: sudo apt-get install python3-setuptools python3-wheel libudunits2-0 python3-pycodestyle python3-coverage python3-numpy
+    # - name: install dependencies (ubuntu 18.04 packages)
+    #   if: matrix.os == 'ubuntu-18.04'
+    #   run: sudo apt-get install python3-setuptools python3-wheel libudunits2-0 python3-pycodestyle python3-coverage python3-numpy
     - name: install dependencies (ubuntu 20.04 packages)
       if: matrix.os == 'ubuntu-20.04'
       run: sudo apt-get install python3-setuptools python3-wheel libudunits2-0 python3-pycodestyle python3-coverage python3-numpy
-    - name: install cfunits (ubuntu 18.04)
-      if: matrix.os == 'ubuntu-18.04'
-      # Config. of cftime=1.5.0 has a key set that fails to be built and
-      # causes an overall error with older setuptools get here, so bypass.
-      run: |
-        python3 -m pip install --upgrade setuptools
-        pip3 install -e .
+    # - name: install cfunits (ubuntu 18.04)
+    #   if: matrix.os == 'ubuntu-18.04'
+    #   # Config. of cftime=1.5.0 has a key set that fails to be built and
+    #   # causes an overall error with older setuptools get here, so bypass.
+    #   run: pip3 install -e .
     - name: install cfunits (ubuntu 20.04)
       if: matrix.os == 'ubuntu-20.04'
       # https://github.com/pypa/pip/issues/7953


### PR DESCRIPTION
Working out a solution, and testing it via re-running the CI jobs, to bypass or fix the `setup.py bdist_wheel` build of `cftime` which fails for the Ubuntu 18.04 (only, i.e. not 20.04 too) distribution job. It seems to occur because `distutils` ends up being run, and that is old enough that it doesn't recognise a(t least one) metadata key in the `cftime` v.1.5.0 `setup.py` (namely `"long_description_content_type"`).

#### Details

Specifically, the Actions log produced the following output:

```
Run pip3 install -e .
Obtaining file:///home/runner/work/cfunits/cfunits
Collecting cftime>=1.5.0 (from cfunits==3.3.4)
  Downloading https://files.pythonhosted.org/packages/c4/1f/a91a359605b4e67b57cc7170370ba24e86d800e8bd8260669165c8d7acce/cftime-1.5.1.1.tar.gz (46kB)
Collecting numpy>=1.15 (from cfunits==3.3.4)
  Downloading https://files.pythonhosted.org/packages/45/b2/6c7545bb7a38754d63048c7696804a0d947328125d81bf12beaa692c3ae3/numpy-1.19.5-cp36-cp36m-manylinux1_x86_64.whl (13.4MB)
Building wheels for collected packages: cftime
  Running setup.py bdist_wheel for cftime: started
  Running setup.py bdist_wheel for cftime: finished with status 'error'
  Complete output from command /usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-ppt2tcet/cftime/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmp60vdbn0bpip-wheel- --python-tag cp36:
  /usr/lib/python3.6/distutils/dist.py:261: UserWarning: Unknown distribution option: 'long_description_content_type'
    warnings.warn(msg)
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib.linux-x86_64-3.6
  creating build/lib.linux-x86_64-3.6/cftime
  copying src/cftime/__init__.py -> build/lib.linux-x86_64-3.6/cftime
  running build_ext
  building 'cftime._cftime' extension
  creating build/temp.linux-x86_64-3.6
  creating build/temp.linux-x86_64-3.6/tmp
  creating build/temp.linux-x86_64-3.6/tmp/pip-build-ppt2tcet
  creating build/temp.linux-x86_64-3.6/tmp/pip-build-ppt2tcet/cftime
  Failed building wheel for cftime
  creating build/temp.linux-x86_64-3.6/tmp/pip-build-ppt2tcet/cftime/src
  creating build/temp.linux-x86_64-3.6/tmp/pip-build-ppt2tcet/cftime/src/cftime
  x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -I/usr/lib/python3/dist-packages/numpy/core/include -I/usr/include/python3.6m -c /tmp/pip-build-ppt2tcet/cftime/src/cftime/_cftime.c -o build/temp.linux-x86_64-3.6/tmp/pip-build-ppt2tcet/cftime/src/cftime/_cftime.o
  x86_64-linux-gnu-gcc: error: /tmp/pip-build-ppt2tcet/cftime/src/cftime/_cftime.c: No such file or directory
  x86_64-linux-gnu-gcc: fatal error: no input files
  compilation terminated.
  error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
  
  ----------------------------------------
  Running setup.py clean for cftime
Failed to build cftime
Installing collected packages: numpy, cftime, cfunits
  Running setup.py install for cftime: started
    Running setup.py install for cftime: finished with status 'error'
    Complete output from command /usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-ppt2tcet/cftime/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-tn2a91ay-record/install-record.txt --single-version-externally-managed --compile --user --prefix=:
    /usr/lib/python3.6/distutils/dist.py:261: UserWarning: Unknown distribution option: 'long_description_content_type'
      warnings.warn(msg)
    running install
    running build
    running build_py
    running build_ext
    building 'cftime._cftime' extension
    creating build/temp.linux-x86_64-3.6
    creating build/temp.linux-x86_64-3.6/tmp
    creating build/temp.linux-x86_64-3.6/tmp/pip-build-ppt2tcet
    creating build/temp.linux-x86_64-3.6/tmp/pip-build-ppt2tcet/cftime
    creating build/temp.linux-x86_64-3.6/tmp/pip-build-ppt2tcet/cftime/src
    creating build/temp.linux-x86_64-3.6/tmp/pip-build-ppt2tcet/cftime/src/cftime
    x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -I/home/runner/.local/lib/python3.6/site-packages/numpy/core/include -I/usr/include/python3.6m -c /tmp/pip-build-ppt2tcet/cftime/src/cftime/_cftime.c -o build/temp.linux-x86_64-3.6/tmp/pip-build-ppt2tcet/cftime/src/cftime/_cftime.o
    x86_64-linux-gnu-gcc: error: /tmp/pip-build-ppt2tcet/cftime/src/cftime/_cftime.c: No such file or directory
    x86_64-linux-gnu-gcc: fatal error: no input files
    compilation terminated.
    error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
    
    ----------------------------------------
Command "/usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-ppt2tcet/cftime/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-tn2a91ay-record/install-record.txt --single-version-externally-managed --compile --user --prefix=" failed with error code 1 in /tmp/pip-build-ppt2tcet/cftime/
Error: Process completed with exit code 1.
```
