### PR TITLE
due to EOL of python 3.6 marked as deprecated in ci workflow

### DIFF
--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -21,7 +21,7 @@ jobs:
     # Set-up the build matrix. We run on different distros and Python versions.
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-10.15, macos-latest]
+        os: [ubuntu-18.04, ubuntu-latest, macos-10.15, macos-latest]
         python-version: [3.7, 3.8, 3.9]
         deprecated: [false]
         beta: [false]

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -26,10 +26,12 @@ jobs:
         deprecated: [false]
         beta: [false]
         include:
-          - python-version: 3.6
+          - os: [ubuntu-latest, macos-latest, macos-10.15]
+            python-version: 3.6
             deprecated: true
             beta: false
           - os: ubuntu-18.04
+            python-version: [3.6, 3.7, 3.8, 3.9]
             deprecated: true
             beta: false
 

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -28,12 +28,12 @@ jobs:
         include:
           - os: [ubuntu-latest, macos-latest, macos-10.15]
             python-version: 3.6
-            deprecated: true
-            beta: false
+            deprecated: [true]
+            beta: [false]
           - os: ubuntu-18.04
             python-version: [3.6, 3.7, 3.8, 3.9]
-            deprecated: true
-            beta: false
+            deprecated: [true]
+            beta: [false]
 
     # ignore error on deprecated or beta versions
     continue-on-error: ${{ matrix.deprecated || matrix.beta }}

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -15,13 +15,26 @@ on:
 # Note a workflow can have 1+ jobs that can run sequentially or in parallel.
 jobs:
   run-test-suite-job_basic:
-    name: run test suite on ubuntu, macos with different python versions
+    #name: run test suite on ubuntu, macos with different python versions
+    name: unix-like, conda
 
     # Set-up the build matrix. We run on different distros and Python versions.
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-18.04, macos-latest, macos-10.15]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        os: [ubuntu-latest, macos-latest, macos-10.15]
+        python-version: [3.7, 3.8, 3.9]
+        deprecated: [false]
+        beta: [false]
+        include:
+          - python-version: 3.6
+            deprecated: true
+            beta: false
+          - os: ubuntu-18.04
+            deprecated: true
+            beta: false
+
+    # ignore error on deprecated or beta versions
+    continue-on-error: ${{ matrix.deprecated || matrix.beta }}
 
     # Run on new and old(er) versions of the distros we support (Linux, Mac OS)
     runs-on: ${{ matrix.os }}
@@ -124,7 +137,15 @@ jobs:
       matrix:
         # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md
         # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-20.04]
+        deprecated: [false]
+        beta: [false]
+        include:
+          - os: ubuntu-18.04
+            deprecated: true
+            beta: false
+    # ignore error on deprecated or beta versions
+    continue-on-error: ${{ matrix.deprecated || matrix.beta }}
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -21,19 +21,29 @@ jobs:
     # Set-up the build matrix. We run on different distros and Python versions.
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-10.15]
+        os: [ubuntu-latest, macos-10.15, macos-latest]
         python-version: [3.7, 3.8, 3.9]
         deprecated: [false]
         beta: [false]
         include:
-          - os: [ubuntu-latest, macos-latest, macos-10.15]
-            python-version: 3.6
-            deprecated: [true]
-            beta: [false]
+          # python 3.6 reached EOL
+          # https://devguide.python.org/#status-of-python-branches
           - os: ubuntu-18.04
-            python-version: [3.6, 3.7, 3.8, 3.9]
-            deprecated: [true]
-            beta: [false]
+            python-version: 3.6
+            deprecated: true
+            beta: false
+          - os: ubuntu-latest
+            python-version: 3.6
+            deprecated: true
+            beta: false
+          - os: macos-10.15
+            python-version: 3.6
+            deprecated: true
+            beta: false
+          - os: macos-latest
+            python-version: 3.6
+            deprecated: true
+            beta: false
 
     # ignore error on deprecated or beta versions
     continue-on-error: ${{ matrix.deprecated || matrix.beta }}
@@ -143,6 +153,8 @@ jobs:
         deprecated: [false]
         beta: [false]
         include:
+          # python 3.6 reached EOL and this version is default on ubuntu-18.04,
+          # therefore ubuntu-18.04 is deprecated
           - os: ubuntu-18.04
             deprecated: true
             beta: false


### PR DESCRIPTION
cf. https://devguide.python.org/#status-of-python-branches

cf. #42 (what a nice number ;-) )