### PR TITLE
Fix `doctest` failures for Python 3.10+ due to `AttributeError` messages

### DIFF
--- a/cfunits/units.py
+++ b/cfunits/units.py
@@ -582,7 +582,7 @@ class Units:
     >>> u.calendar
     Traceback (most recent call last):
         ...
-    AttributeError: Units has no attribute 'calendar'
+    AttributeError: Units has no attribute 'calendar'...
     >>> v = Units('days since 2000-1-1', 'standard')
     >>> v.calendar
     'standard'
@@ -1765,7 +1765,7 @@ class Units:
         >>> Units('days since 2001-1-1').calendar
         Traceback (most recent call last):
             ...
-        AttributeError: Units has no attribute 'calendar'
+        AttributeError: Units has no attribute 'calendar'...
 
         """
         value = self._calendar


### PR DESCRIPTION
Quick one to fix some `doctest` failures for a full tests suite pass across supported Python 3.X versions. Notably there were a few failures due to the feature introduced in Python 3.10 which adds "Did you mean ..." suggestions to some error messages, such that Python 3.8 gives a shorter `AttributeError` and in the affected cases:


```python
Python 3.8.17 | packaged by conda-forge | (default, Jun 16 2023, 07:06:00) 
[GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import cfunits
>>> cfunits.Units('days since 2000-1-1').calendar
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/slb93/git-repos/cfunits/cfunits/units.py", line 1775, in calendar
    raise AttributeError(
AttributeError: Units has no attribute 'calendar'
```
whereas e.g. Python 3.12 will show the extended message:

```python
Python 3.12.0 | packaged by conda-forge | (main, Oct  3 2023, 08:43:22) [GCC 12.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import cfunits
>>> cfunits.Units('days since 2000-1-1').calendar
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/slb93/git-repos/cfunits/cfunits/units.py", line 1775, in calendar
    raise AttributeError(
AttributeError: Units has no attribute 'calendar'. Did you mean: '_calendar'?
```

The ellipsis `...` marker indicates any text is acceptable and will ensure the tests pass for both message versions, and users can interpret it in the natural way as 'there may be further text after this', so it works for both machine and human.